### PR TITLE
change ctdTrim to skip bilinear fit if pmin specified

### DIFF
--- a/R/ctd.R
+++ b/R/ctd.R
@@ -534,7 +534,12 @@ ctdTrim <- function(x, method=c("downcast", "index", "range"),
             }
             pmin <- -5
             if (!missing(parameters)) {
-                if ("pmin" %in% names(parameters)) pmin <- parameters$pmin else stop("parameter not understood for this method")
+                if ("pmin" %in% names(parameters)) {
+                    pmin <- parameters$pmin
+                    pminGiven <- TRUE
+                } else {
+                    stop("parameter not understood for this method")
+                }
             }
             oceDebug(debug, 'pmin=', pmin, '\n')
             keep <- (x@data$pressure > pmin) # 2. in water (or below start depth)
@@ -571,7 +576,7 @@ ctdTrim <- function(x, method=c("downcast", "index", "range"),
             ## 2011-02-04     equilibration <- (predict(m <- lm(pp ~ ss), newdata=list(ss=x@data$scan)) < 0)
             ## 2011-02-04     keep[equilibration] <- FALSE
             ## 2011-02-04 }
-            if (TRUE) {                 # new method, after Feb 2008
+            if (!pminGiven) {                 # new method, after Feb 2008
                 bilinear1 <- function(s, s0, dpds) {
                     ifelse(s < s0, 0, dpds*(s-s0))
                 }

--- a/man/ctdTrim.Rd
+++ b/man/ctdTrim.Rd
@@ -28,11 +28,15 @@ parameters, debug=getOption("oceDebug"))}
 	    decibars) is used instead as the lower limit.  This is a
 	    commonly-used setup, e.g. \code{ctdTrim(ctd,
 	    parameters=list(pmin=1))} removes the top decibar
-	    (roughly 1m) from the data.}
+	    (roughly 1m) from the data. Specifying \code{pmin} is a
+            simple way to remove near-surface data, such as a shallow
+	    equilibration phase, and if specified will cause
+            \code{ctdTrim} to skip step 4 below.}
 	  \item{Step 3.}{The maximum pressure is determined, and data
 	    acquired subsequent to that point are deleted.  This removes
 	    the upcast and any subsequent data.}
-	  \item{Step 4.}{An initial equilibrium phase is removed by a
+	  \item{Step 4.}{If the \code{pmin} parameter is not specified,
+            an attempt is made to remove an initial equilibrium phase by a
 	    regression of pressure on scan number.  The model has zero
 	    pressure for some initial portion, and then a constant
 	    increase with scan number.  Then this initial zero-pressure


### PR DESCRIPTION
I made some changes to `ctdTrim()` based on a data file I was working with. I can send you the data if you want (but it's a bit complicated since the raw data are in a totally stupid format that requires a whole bunch of parsing just to be able to use `read.table()` and then `as.ctd()`).

Anyway, the problem I was finding was that using `ctdTrim()` was taking off *way* too much surface data, based on the bilinear fit to remove an equilibration phase. The cause of this was that there *was'nt* an equilibration phase in the data (it had already been chopped off in the data reading process), but because the `nls()` didn't fail, it was just happily trimming away the top 50 m of good data.

After noodling with the code for awhile, I decided that the easiest way around this was to just *skip* the bilinear fit whenever the `pmin` parameter is provided. To me, the point of `pmin` is essentially a crude way to get rid of any garbage near-surface data anyway, so it seems redundant to both trim to `pmin` *and* try to remove a zero-pressure region[^1]. It's conceivable (and highly likely, I think) that this same issue will come up whenever `pmin` is specified deep enough to remove any real equilibration phase.

[1]: As a note, I noticed that the bilinear fit fits the flat portion of pressure to zero. Seems like it wouldn't be to hard to make it fit to something more sensible, say, the mean pressure of the first few points. I guess that's another issue though.