### PR TITLE
Doc updates for adp class.

### DIFF
--- a/man/adp-class.Rd
+++ b/man/adp-class.Rd
@@ -80,11 +80,11 @@
     heading (\code{adp[["heading"]]}) pitch (\code{adp[["pitch"]]}), and roll
     (\code{adp[["roll"]]}), depending on the setup of the instrument.
 
-    The precise meanings of the data items depend on the instrument type.  All
-    instruments have \code{v} (for velocity), \code{q} (for a measure of data
-    quality) and \code{a} (for a measure of backscatter amplitude).  Devices
-    from Teledyne-RDI profilers have an additional item \code{g} (for
-    percent-good).
+    The precise meanings of the data items depend on the instrument
+    type.  All instruments have \code{v} (for velocity), \code{q} (for a
+    measure of data quality) and \code{a} (for a measure of backscatter
+    amplitude, also called echo intensity).  Devices from Teledyne-RDI
+    profilers have an additional item \code{g} (for percent-good).
     
     For RDI profilers, there are four three-dimensional arrays holding beamwise
     data.  In these, the first index indicates time, the second bin number, and
@@ -99,8 +99,9 @@
         \item \code{q} is ``correlation magnitude'' a one-byte quantity stored
         as type \code{raw} in the object. The values may range from 0 to 255.
 
-        \item \code{a} is ``echo intensity'' a one-byte quantity stored as type
-        \code{raw} in the object.  The values may range from 0 to 255.
+        \item \code{a} is ``backscatter amplitude``, also known as
+        ``echo intensity'' a one-byte quantity stored as type \code{raw}
+        in the object.  The values may range from 0 to 255.
 
         \item \code{g} is ``percent good'' a one-byte quantity stored as
         \code{raw} in the object.  The values may range from 0 to 100.

--- a/man/read.adp.Rd
+++ b/man/read.adp.Rd
@@ -159,7 +159,8 @@ read.adp.sontek.serial(file, from=1, to, by=1, tz=getOption("oceTz"),
   \item{\code{roll}}{The roll of the instrument, in degrees.}
   \item{\code{v}}{A 3-D matrix of velocity.  The first index corresponds to
       profile number, the second to cell number, and the third to beam number.}
-  \item{\code{a}}{A 3-D matrix of backscatter amplitude, corresponding to \code{v}.}
+  \item{\code{a}}{A 3-D matrix of backscatter amplitude, also known as
+      echo intensity, corresponding to \code{v}.}
   \item{\code{q}}{A 3-D matrix of a measure of the quality of the data,
       corresponding to \code{v}.}
   \item{\code{br}}{Depth to bottom in each of 4 beams (only for Teledyne-RDI


### PR DESCRIPTION
Cleaned up the adp related docs to remove some ambiguities and
inconsistencies regarding the "amplitude" variable. Sometimes it is
called backscatter amplitude, sometimes backscatter intensity, but
also "echo intensity" is a common term in the ADCP literature.