### PR TITLE
fix to read.logger for when there are more names than data channels

### DIFF
--- a/R/logger.R
+++ b/R/logger.R
@@ -385,7 +385,7 @@ read.logger <- function(file, from=1, to, by=1, type, tz=getOption("oceTz", defa
         DBI::dbClearResult(res)
         ## Get column names from the 'channels' table.
         names <- tolower(RSQLite::dbReadTable(con, "channels")$longName)
-        names(data) <- names
+        names(data) <- names[1:dim(data)[2]] # sometimes there are more names than data channels
         data <- as.list(data)
 
         ## message("dim of data: ", paste(dim(data), collapse="x"))


### PR DESCRIPTION
Not exactly sure what is going on with this yet, but it seems like an
RSK file *can* be populated with more "names" than there are data
channels. This seems to occur because sometimes derived variables are
stored in the database, and if they aren't the names are anyway.

The problem was in the line:

names(data) <- names

which I changed to

names(data) <- names[1:dim(data)[2]]

so that it only assigns names to the channels that are actually in the database.