### PR TITLE
Fix ctdFindProfiles for error when calling ctdTrim.

### DIFF
--- a/R/ctd.R
+++ b/R/ctd.R
@@ -475,8 +475,7 @@ ctdFindProfiles<- function(x, cutoff=0.5, minLength=10, minHeight=0.1*diff(range
         casts <- vector("list", ncasts)
         for (i in 1:ncasts) {
             oceDebug(debug, "profile #", i, "of", ncasts, "\n")
-            ii <- seq.int(indices$start[i], indices$end[i])
-            cast <- ctdTrim(x, "index", parameters=ii)
+            cast <- ctdTrim(x, "index", parameters=c(indices$start[i], indices$end[i]))
             cast@processingLog <- processingLog(cast@processingLog,
                                                 paste(paste(deparse(match.call()), sep="", collapse=""),
                                                 " # profile ", i, " of ", ncasts))


### PR DESCRIPTION
This seems to be related to changes in the `parameters` arg in
ctdTrim() when `method='index'`. Below is an example that reproduces
the error:

```r
library(oce)
data(ctdRaw)
ctd <- as.ctd(rep(ctdRaw[['salinity']], 2), rep(ctdRaw[['temperature']], 2), rep(ctdRaw[['pressure']], 2))
ctdFindProfiles(ctd)
```
```
Error in ctdTrim(x, "index", parameters = ii) :
  length of parameters must be 2, or must match the ctd column length
```