### PR TITLE
Add conductivity plots to plot.ctd and plotProfile

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -806,7 +806,7 @@ matchBytes <- function(input, b1, ...)
         stop("must provide 2 or 3 bytes")
 }
 
-resizableLabel <- function(item=c("S", "T", "theta", "sigmaTheta",
+resizableLabel <- function(item=c("S", "C", "T", "theta", "sigmaTheta",
                                   "conservative temperature", "absolute salinity",
                                   "nitrate", "nitrite", "oxygen", "phosphate", "silicate",
                                   "tritium", "spice", "fluorescence",
@@ -829,6 +829,16 @@ resizableLabel <- function(item=c("S", "T", "theta", "sigmaTheta",
         } else {
             full <- bquote(.(var)*" ( "*degree*"C )")
             abbreviated <- expression(paste("T (", degree, "C)"))
+        }
+    } else if (item == "C") {
+        var <- gettext("Conductivity", domain="R-oce")
+        unit <- gettext("mS/cm", domain="R-oce") #FIXME: how to handle different possible units?
+        if (getOption("oceUnitBracket") == '[') {
+            full <- paste(var, "[", unit, "]")
+            abbreviate <- full
+        } else {
+            full <- paste(var, "(", unit, ")")
+            abbreviate <- full
         }
     } else if (item == "conservative temperature") {
         var <- gettext("Conservative Temperature", domain="R-oce")

--- a/man/plot.ctd.Rd
+++ b/man/plot.ctd.Rd
@@ -17,7 +17,7 @@
      ref.lat=NaN, ref.lon=NaN, 
      grid=TRUE,
      coastline="best",
-     Slim, Tlim, plim, densitylim, N2lim, Rrholim,
+     Slim, Clim, Tlim, plim, densitylim, N2lim, Rrholim,
      dpdtlim, timelim,
      lonlim, latlim,
      clongitude, clatitude, span, showHemi=TRUE,
@@ -70,6 +70,9 @@
       \item \code{which=12} or \code{which="N2"} gives an \eqn{N^2}{N^2} profile
       \item \code{which=13} or \code{which="spice"} gives a spiciness profile
       \item \code{which=14} or \code{which="tritium"} gives a tritium profile
+      \item \code{which=15} or \code{which="Rrho"} gives an Rrho profile
+      \item \code{which=16} or \code{which="RrhoSF"} gives an RrhoSF profile
+      \item \code{which=17} or \code{which="conductivity"} gives a conductivity profile
     }
   }
   \item{col}{colour of lines or symbols}

--- a/man/plotProfile.Rd
+++ b/man/plotProfile.Rd
@@ -22,7 +22,7 @@
     grid=TRUE,
     col.grid="lightgray",
     lty.grid="dotted",
-    Slim, Tlim, densitylim, N2lim, Rrholim, dpdtlim, timelim, ylim,
+    Slim, Clim, Tlim, densitylim, N2lim, Rrholim, dpdtlim, timelim, ylim,
     lwd=par("lwd"),
     xaxs="r", yaxs="r",
     cex=1, pch=1,
@@ -39,11 +39,12 @@
 }
 
 \arguments{
-    \item{x}{A \code{cdt} object, e.g. as read by \code{\link{read.ctd}}.}
+    \item{x}{A \code{ctd} object, e.g. as read by \code{\link{read.ctd}}.}
     \item{xtype}{Item(s) plotted on the x axis, either a vector of length equal
         to that of \code{x@data$pressure} or a text code from the list below.
         \describe{
             \item{\code{"salinity"}}{Profile of salinity.}
+            \item{\code{"conductivity"}}{Profile of conductivity.}
             \item{\code{"temperature"}}{Profile of \emph{in-situ} temperature.}
             \item{\code{"theta"}}{Profile of \emph{potential} temperature.}
             \item{\code{"density"}}{Profile of density (expressed as

--- a/man/resizableLabel.Rd
+++ b/man/resizableLabel.Rd
@@ -8,7 +8,7 @@
     Temperature, and including units as appropriate.}
 
 \usage{
-resizableLabel(item=c("S", "T", "theta", "sigmaTheta",
+resizableLabel(item=c("S", "C", "T", "theta", "sigmaTheta",
   "conservative temperature", "absolute salinity",
   "nitrate", "nitrite", "oxygen", "phosphate", "silicate",
   "tritium", "spice", "fluorescence",


### PR DESCRIPTION
This is a big pull request, and possibly some of the code is not up to your spec, so don't feel like you have to merge the whole thing. I broke the changes into separate commits to make it a bit easier to parse.

Note that the commit message for 67c9247 should have specified that the function modified was `resizeableLabel()`, in the `misc.R` file, not `plotProfile()`. Sorry.