### PR TITLE
fix plotProfile conductivity type to display ratio as unit

### DIFF
--- a/R/ctd.R
+++ b/R/ctd.R
@@ -2942,7 +2942,7 @@ plotProfile <- function (x,
         if ('conductivity' %in% names(x@data)) {
             conductivity <- x@data$conductivity
         } else {
-            conductivity <- swCSTp(x[['salinity']], x[['temperature']], x[['pressure']], eos=eos)*42.91754 # mS/cm
+            conductivity <- swCSTp(x[['salinity']], x[['temperature']], x[['pressure']], eos=eos)
         }
         if (!any(is.finite(conductivity))) {
             warning("no valid conductivity data")

--- a/R/misc.R
+++ b/R/misc.R
@@ -832,7 +832,7 @@ resizableLabel <- function(item=c("S", "C", "T", "theta", "sigmaTheta",
         }
     } else if (item == "C") {
         var <- gettext("Conductivity", domain="R-oce")
-        unit <- gettext("mS/cm", domain="R-oce") #FIXME: how to handle different possible units?
+        unit <- gettext("ratio", domain="R-oce") #FIXME: how to handle different possible units?
         if (getOption("oceUnitBracket") == '[') {
             full <- paste(var, "[", unit, "]")
             abbreviate <- full


### PR DESCRIPTION
Updated my previous fix for having a `conductivity` type for `plotProfile()` to not put the "mS/cm" unit on the axis, but instead to put "ratio" (which is the default stored in ctd objects now).