### PR TITLE
fix typo in oceSetData that was sticking it in metadata

### DIFF
--- a/R/accessors.R
+++ b/R/accessors.R
@@ -100,7 +100,7 @@ oceSetData <- function(object, name, value, note="")
 {
     if (!inherits(object, "oce"))
         stop("oceGetData() only works for oce objects")
-    object@metadata[[name]] <- value
+    object@data[[name]] <- value
     object@processingLog <- processingLogAppend(object@processingLog, paste(deparse(match.call()), sep="", collapse=""))
     if (nchar(note) > 0)
         object@processingLog <- processingLogAppend(object@processingLog, note)


### PR DESCRIPTION
small typo that was causing `oceSetData()` to actually add the field to `@metadata`.