### PR TITLE
fix to read rsk txt exports with lots of events

### DIFF
--- a/R/rsk.R
+++ b/R/rsk.R
@@ -481,7 +481,11 @@ read.rsk <- function(file, from=1, to, by=1, type, tz=getOption("oceTz", default
     } else if (!(missing(type)) && type=='txt') {
         oceDebug('RBR txt format\n')
         oceDebug(debug, "Format is Rtext Ruskin txt export", "\n")
-        l <- readLines(file, n=1000)         # read first 1000 lines to get header
+        l <- readLines(file, n=50000)         # FIXME: need to read a
+                                              # lot if there are lots
+                                              # of "Events". Is there
+                                              # a better way to do
+                                              # this?
         pushBack(l, file)
         model <- unlist(strsplit(l[grep('Model', l, useBytes=TRUE)], '='))[2]
         serialNumber <- as.numeric(unlist(strsplit(l[grep('Serial', l, useBytes=TRUE)], '='))[2])


### PR DESCRIPTION
Had to make this change to read a txt file that had a large number of "events" written before the data table. Drinking in only the first 1000 lines wasn't enough to determine where to start reading the data.

This is a hacky fix, and we may want to think about doing it more cleverly, but there are other rsk txt export changes coming down the pipes which will make parsing easier, so I don't think that such a fix is a high priority right now.