### PR TITLE
Finding different *.nod files

### DIFF
--- a/R/tidem.R
+++ b/R/tidem.R
@@ -635,16 +635,8 @@ webtide <- function(action=c("map", "predict"),
     triangles <- NULL
     warn <- options("warn")$warn
     options(warn=-1)
-    t <- try({ triangles <- read.table(paste(subdir, "/", region, ".nod", sep=""),
-        col.names=c("triangle","longitude","latitude")) }, silent=TRUE)
-    if (inherits(t, "try-error")) {
-        t <- try({ triangles <- read.table(paste(subdir, "/", region, "ll.nod", sep=""),
-            col.names=c("triangle","longitude","latitude")) }, silent=TRUE)
-        if (inherits(t, "try-error")) {
-            t <- try({ triangles <- read.table(paste(subdir, "/", region, "_ll.nod", sep=""),
-                col.names=c("triangle","longitude","latitude")) }, silent=TRUE)
-        }
-    }
+    t <- try({ triangles <- read.table(paste(subdir, "/", list.files(path=subdir,pattern="*.nod"), sep=""),
+                                     col.names=c("triangle","longitude","latitude")) }, silent=TRUE)
     if (is.null(triangles))
         stop("Could not find the '.nod' file")
     options(warn=warn)


### PR DESCRIPTION
If there are different naming standards used at the moment, this might be a better solution, just looking for a .nod file in the folder (just in case new datasets are added and a different naming standard is used). As far as I can see there is always just 1 nod file in the data folder.

All the datasets I tested worked alright with this patch (tested on artic9, brador, h3o, HRglobal, ne_pac4, mwatl, sshelf).