### PR TITLE
use rule=2 for despike to avoid end problems

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -1492,7 +1492,7 @@ despikeColumn <- function(x, reference=c("median", "smooth", "trim"), n=4, k=7, 
     na <- is.na(x)
     if (sum(na) > 0) {
         i <- 1:nx
-        x.gapless <- approx(i[!na], x[!na], i)$y
+        x.gapless <- approx(i[!na], x[!na], i, rule=2)$y
     } else {
         x.gapless <- x
     }


### PR DESCRIPTION
slight adjustment to the use off `approx()` in `despike()` too allow it to be used when there are NAs at the beginning or end of a series