### PR TITLE
permit NA's in swCSTp

### DIFF
--- a/R/sw.R
+++ b/R/sw.R
@@ -427,7 +427,7 @@ swCSTp <- function(salinity=35, temperature=15, pressure=0,
     eos <- match.arg(eos, c("unesco", "gsw"))
     if (eos == "unesco") {
         n <- length(salinity)
-        res <- .C("sw_CSTp", as.integer(n), as.double(salinity), T68fromT90(as.double(temperature)), as.double(pressure), C=double(n))$C
+        res <- .C("sw_CSTp", as.integer(n), as.double(salinity), T68fromT90(as.double(temperature)), as.double(pressure), C=double(n), NAOK=TRUE, PACKAGE="oce")$C
     } else {
         ## for the use of a constant, as opposed to a function call with (35,15,0), see
         ## https://github.com/dankelley/oce/issues/746


### PR DESCRIPTION
I discovered that `swCSTp()` doesn't allow NAs in the input, whereas other similar functions such as `swSCTp()` do. The fix seemed to be to add `NAOK=TRUE` to the `.C` call, which I did.

NB I also added `PACKAGE="oce"`, to be consistent with the `swSCTp()` call, but I'm not 100% if it's needed or is the right thing to do.

