### PR TITLE
colormap fix missing zcol for NA values (issue 1082)

### DIFF
--- a/R/colors.R
+++ b/R/colors.R
@@ -594,9 +594,6 @@ colormap <- function(z=NULL,
 {
     oceDebug(debug, "colormap() {\n", unindent=1)
     zKnown <- !is.null(z)
-    if (zKnown) {
-        z <- z[is.finite(z)]
-    }
     zlimKnown <- !missing(zlim)
     if (zlimKnown) {
         if (length(zlim) != 2)
@@ -678,7 +675,7 @@ colormap <- function(z=NULL,
             zlimKnown <- TRUE
         } else if (zKnown) {
             oceDebug(debug, "zlimKnown=", zlimKnown, ", so inferring zlim from z\n", sep="")
-            zlim <- rangeExtended(z)
+            zlim <- rangeExtended(z[is.finite(z)])
             zlimKnown <- TRUE
         ##} else if (x0Known) {
         ##    oceDebug(debug, "zlimKnown=", zlimKnown, ", so inferring zlim from x0 and x1\n", sep="")


### PR DESCRIPTION
This should fix Issue #1082, but not cause problems with Issue #1000 where the original "finite only" fix was made.

I did this as a branch on the main oce repo, because I have unmerged changes in my own fork, and am submitting as a pull request so that @dankelley can review. This is the first time I've done a PR like this, so I hope it works!