### PR TITLE
Speed improvements to read.rsk() from @jkennel

### DIFF
--- a/R/rsk.R
+++ b/R/rsk.R
@@ -742,6 +742,14 @@ read.rsk <- function(file, from=1, to, by=1, type, tz=getOption("oceTz", default
 
         ## Get time stamp. Note the trick of making it floating-point
         ## to avoid the problem that R lacks 64 bit integers.
+        fields <- DBI::dbListFields(con, "data")
+        fields <- fields[!grepl('tstamp', fields)]
+        sql_fields <- paste0("1.0*tstamp AS tstamp")
+        
+        sql_fields <- paste(c(sql_fields, fields), collapse=',')
+        sql_fields <- paste("SELECT", sql_fields, "FROM data")
+        
+        
         res <- DBI::dbSendQuery(con, "select 1.0*tstamp from data order by tstamp;")
         t1000 <- DBI::dbFetch(res, n=-1)[[1]]
         RSQLite::dbClearResult(res)

--- a/R/rsk.R
+++ b/R/rsk.R
@@ -643,6 +643,12 @@ read.rsk <- function(file, from=1, to, by=1, type, tz=getOption("oceTz", default
     ##measurement.deltat <- 0
     if (is.numeric(from) && from < 1)
         stop("from cannot be an integer less than 1")
+    
+    if(!missing(to)){
+      if (is.numeric(to) && to < 1)
+        stop("to cannot be an integer less than 1")
+    }
+    
     ##from.keep <- from
     if (!missing(to))
         to.keep <- to


### PR DESCRIPTION
The biggest gain in speed comes from reading tstamp ahead of time only when needed.  ie when to/from are integers and not equal to 1