### PR TITLE
Fix two aquadopp bugs -- one for axis plotting and one for NA values

### DIFF
--- a/R/adp.R
+++ b/R/adp.R
@@ -1567,8 +1567,8 @@ setMethod(f="plot",
                                                  tformat=tformat,
                                                  adorn=adorn[w],
                                                  debug=debug-1)
-                              res$xat <- grid$xat
-                              res$yat <- grid$yat
+                              res$xat <- ats$xat
+                              res$yat <- ats$yat
                           }
                       }
                       drawTimeRange <- FALSE

--- a/R/adp.nortek.R
+++ b/R/adp.nortek.R
@@ -773,13 +773,13 @@ read.adp.nortek <- function(file, from=1, to, by=1, tz=getOption("oceTz"),
                      heading=heading,
                      pitch=pitch,
                      roll=roll)
-    ## FIXME: Sometimes there can be an extra sample, with a time of
-    ## NA Because the times are continuous without the extra sample,
+    ## Sometimes there can be an extra sample, with a time of
+    ## NA. Because the times are continuous without the extra sample,
     ## for now I'll just remove the entire sample
     tNA <- which(is.na(time))
     if (length(tNA) > 0) {
         for (field in names(res@data)) {
-            if (!('field' %in% distance)) {
+            if (!(field %in% 'distance')) {
                 if (field %in% c('v', 'a', 'q')) {
                     res@data[[field]] <- res@data[[field]][-tNA, , , drop=FALSE]
                 } else {
@@ -787,6 +787,7 @@ read.adp.nortek <- function(file, from=1, to, by=1, tz=getOption("oceTz"),
                 }
             }
         }
+        warning(paste('Found and removed', length(tNA), 'NAs in the time vector.'))
     }
     
     if (type == "aquadopp" && diaToRead > 0) {

--- a/R/adp.nortek.R
+++ b/R/adp.nortek.R
@@ -768,12 +768,14 @@ read.adp.nortek <- function(file, from=1, to, by=1, tz=getOption("oceTz"),
     ## NA Because the times are continuous without the extra sample,
     ## for now I'll just remove the entire sample
     tNA <- which(is.na(time))
-    for (field in names(res@data)) {
-        if (!('field' %in% distance)) {
-            if (field %in% c('v', 'a', 'q')) {
-                res@data[[field]] <- res@data[[field]][-tNA, , , drop=FALSE]
-            } else {
-                res@data[[field]] <- res@data[[field]][-tNA]
+    if (length(tNA) > 0) {
+        for (field in names(res@data)) {
+            if (!('field' %in% distance)) {
+                if (field %in% c('v', 'a', 'q')) {
+                    res@data[[field]] <- res@data[[field]][-tNA, , , drop=FALSE]
+                } else {
+                    res@data[[field]] <- res@data[[field]][-tNA]
+                }
             }
         }
     }

--- a/R/adp.nortek.R
+++ b/R/adp.nortek.R
@@ -764,6 +764,20 @@ read.adp.nortek <- function(file, from=1, to, by=1, tz=getOption("oceTz"),
                      heading=heading,
                      pitch=pitch,
                      roll=roll)
+    ## FIXME: Sometimes there can be an extra sample, with a time of
+    ## NA Because the times are continuous without the extra sample,
+    ## for now I'll just remove the entire sample
+    tNA <- which(is.na(time))
+    for (field in names(res@data)) {
+        if (!('field' %in% distance)) {
+            if (field %in% c('v', 'a', 'q')) {
+                res@data[[field]] <- res@data[[field]][-tNA, , , drop=FALSE]
+            } else {
+                res@data[[field]] <- res@data[[field]][-tNA]
+            }
+        }
+    }
+    
     if (type == "aquadopp" && diaToRead > 0) {
         ## FIXME: there may be other things here, e.g. does it try to measure salinity?
         res@data$timeDia <- timeDia


### PR DESCRIPTION
In doing some work on some (private) aquadopp files recently, I discovered that something seemed to be broken about the adp plot method for such instruments.

Also, I discovered that apparently sometimes an aquadopp file can have an "extra" sample, for which the time is `NA`, but other values exist, but the remaining times are all consecutive as would be expected without the NA. I don't know what causes this, and it should probably be looked into further (are we reading something wrong in the file?), but for now I added a check for such "NA times" and just remove the ensemble if any are found.

It just occurred to me that it might be a good idea to add a read-time warning that such an ensemble was found and removed.