### PR TITLE
Fix issue #1171; add profile arg to as.ctd(argo)

### DIFF
--- a/R/ctd.R
+++ b/R/ctd.R
@@ -726,7 +726,7 @@ setMethod(f="[[<-",
 #' is extracted and the other arguments to \code{as.ctd} are ignored, except for
 #' \code{pressureAtmospheric}. If the first argument has salinity, etc., in
 #' matrix form (as can happen with some objects of \code{\link{argo-class}}),
-#' then only the first column is used, and a warning to that effect is given.
+#' then only the first column is used, and a warning to that effect is given, unless the \code{profile} argument is specified and then that specific profile is extracted.
 #' If the first argument is an object of \code{\link{rsk-class}},
 #' then \code{as.ctd} merely passes
 #' it and \code{pressureAtmospheric} to \code{\link{rsk2ctd}}, which
@@ -863,6 +863,10 @@ setMethod(f="[[<-",
 #' @param sampleInterval optional numerical value indicating the time between
 #' samples in the profile.
 #'
+#' @param profile optional value specifying the number of the profile to
+#'     extract from an object with data in matrices, such as for some
+#'     \code{argo} objects. Must be a numeric of length one.
+#'
 ##1108 @param src optional string indicating data source.
 #'
 #' @template debugTemplate
@@ -918,6 +922,7 @@ as.ctd <- function(salinity, temperature=NULL, pressure=NULL, conductivity=NULL,
                    pressureAtmospheric=0,
                    ##1108 waterDepth=NA,
                    sampleInterval=NA,
+                   profile,
                    ##1108 src="",
                    debug=getOption("oceDebug"))
 {
@@ -1024,15 +1029,20 @@ as.ctd <- function(salinity, temperature=NULL, pressure=NULL, conductivity=NULL,
                 ##res <- ctdAddColumn(res, column=d[[field]], name=field, label=field, log=FALSE)
                 dataInField <- d[[field]]
                 if (is.matrix(dataInField)) {
+                    if (missing(profile)) {
+                        profile <- 1
+                        warning("using just column 1 of matrix data; use the 'profile' argument to select a specific profile or try as.section() to keep all columns")
+                    }
+                    if (!is.numeric(profile) | length(profile) != 1) {
+                        stop('profile argument must be a numeric value of length one.')
+                    }
                     convertedMatrix <- TRUE
-                    res@data[[field]] <- d[[field]][, 1]
+                    res@data[[field]] <- d[[field]][, profile]
                 } else {
                     res@data[[field]] <- d[[field]]
                 }
             }
         }
-        if (convertedMatrix)
-            warning("using just column 1 of matrix data; try as.section() to keep all columns")
         if ("longitude" %in% dnames && "latitude" %in% dnames) {
             longitude <- d$longitude
             latitude <- d$latitude

--- a/man/as.ctd.Rd
+++ b/man/as.ctd.Rd
@@ -9,7 +9,7 @@ as.ctd(salinity, temperature = NULL, pressure = NULL, conductivity = NULL,
   missingValue = NULL, type = "", serialNumber = "", ship = "",
   cruise = "", station = "", startTime = NULL, longitude = NA,
   latitude = NA, deploymentType = "unknown", pressureAtmospheric = 0,
-  sampleInterval = NA, debug = getOption("oceDebug"))
+  sampleInterval = NA, profile, debug = getOption("oceDebug"))
 }
 \arguments{
 \item{salinity}{There are three choices for \code{salinity}. (1) It can be a
@@ -21,7 +21,7 @@ salinity, temperature, etc., can be inferred. In that case, the relevant informa
 is extracted and the other arguments to \code{as.ctd} are ignored, except for
 \code{pressureAtmospheric}. If the first argument has salinity, etc., in
 matrix form (as can happen with some objects of \code{\link{argo-class}}),
-then only the first column is used, and a warning to that effect is given.
+then only the first column is used, and a warning to that effect is given, unless the \code{profile} argument is specified and then that specific profile is extracted.
 If the first argument is an object of \code{\link{rsk-class}},
 then \code{as.ctd} merely passes
 it and \code{pressureAtmospheric} to \code{\link{rsk2ctd}}, which
@@ -104,6 +104,10 @@ that is to be computed from \code{conductivity}, etc., using
 
 \item{sampleInterval}{optional numerical value indicating the time between
 samples in the profile.}
+
+\item{profile}{optional value specifying the number of the profile to
+extract from an object with data in matrices, such as for some
+\code{argo} objects. Must be a numeric of length one.}
 
 \item{debug}{an integer specifying whether debugging information is
 to be printed during the processing. This is a general parameter that


### PR DESCRIPTION
Hoping @dankelley can give this a quick code review and merge if it looks ok. I changed the warning a bit so that it only warns when `profile=` isn't specified (because presumably otherwise the user would know what they were doing).