### PR TITLE
Fix issue where nav data was not being read for VMDAS files

### DIFF
--- a/R/adp.rdi.R
+++ b/R/adp.rdi.R
@@ -215,7 +215,7 @@ decodeHeaderRDI <- function(buf, debug=getOption("oceDebug"), tz=getOption("oceT
     ##tpp.seconds <- readBin(FLD[24], "integer", n=1, size=1)
     ##tpp.hundredths <- readBin(FLD[25], "integer", n=1, size=1)
     coordTransform <- byteToBinary(FLD[26], endian="big")
-    bits <- substr(byteToBinary(FLD[26], endian="big"), 4, 5)    
+    bits <- substr(byteToBinary(FLD[26], endian="big"), 4, 5)
     originalCoordinate <- "???"
     if (bits == "00") originalCoordinate <- "beam"
     else if (bits == "01") originalCoordinate <- "xyz"
@@ -468,7 +468,7 @@ decodeHeaderRDI <- function(buf, debug=getOption("oceDebug"), tz=getOption("oceT
 #' (e.g. for call-by-value in function evaluation), \code{read.adp.rdi} uses a safety
 #' factor in its calculation of when to auto-decimate a file. This factor is set to 3,
 #' based partly on the developers' experience with datasets in their possession.
-#' Multiplied by the previously stated safety factor of 3, 
+#' Multiplied by the previously stated safety factor of 3,
 #' this suggests that the 2 GB limit on R objects corresponds to approximately a
 #' 222 MB limit on file size. In the present version of \code{read.adp.rdi}, this
 #' value is lowered to 200 MB for simplicity. Larger files are considered to be "big",
@@ -477,7 +477,7 @@ decodeHeaderRDI <- function(buf, debug=getOption("oceDebug"), tz=getOption("oceT
 #' The decimation procedure has two cases.
 #' \enumerate{
 #' \item \emph{Case 1.} If \code{from=1} and
-#' \code{to=0} (or if neither \code{from} or \code{to} is given), then the 
+#' \code{to=0} (or if neither \code{from} or \code{to} is given), then the
 #' intention is to process the full span of the data.  If the input file is
 #' under 200 MB, then \code{by} defaults to 1, so that all profiles are read.
 #' For larger files, \code{by} is set to the \code{\link{ceiling}} of the
@@ -1572,6 +1572,58 @@ read.adp.rdi <- function(file, from, to, by, tz=getOption("oceTz"),
                br[br == 0.0] <- NA    # clean up (not sure if needed)
                res@data <- list(v=v, q=q, a=a, g=g,
                                 br=br, bv=bv,
+                                distance=seq(bin1Distance, by=cellSize, length.out=numberOfCells),
+                                time=time,
+                                pressure=pressure,
+                                temperature=temperature,
+                                salinity=salinity,
+                                depth=depth,
+                                soundSpeed=soundSpeed,
+                                heading=heading,
+                                pitch=pitch,
+                                roll=roll,
+                                headingStd=headingStd,
+                                pitchStd=pitchStd,
+                                rollStd=rollStd,
+                                pressureStd=pressureStd,
+                                xmitCurrent=xmitCurrent,
+                                xmitVoltage=xmitVoltage,
+                                ambientTemp=ambientTemp,
+                                pressurePlus=pressurePlus,
+                                pressureMinus=pressureMinus,
+                                attitudeTemp=attitudeTemp,
+                                attitude=attitude,
+                                contaminationSensor=contaminationSensor,
+                                ## Next are as described starting on p77 of VmDas_Users_Guide_May12.pdf
+                                avgSpeed=avgSpeed,
+                                avgMagnitudeVelocityEast=avgMagnitudeVelocityEast,
+                                avgMagnitudeVelocityNorth=avgMagnitudeVelocityNorth,
+                                avgTrackMagnetic=avgTrackMagnetic,
+                                avgTrackTrue=avgTrackTrue,
+                                avgTrueVelocityEast=avgTrueVelocityEast,
+                                avgTrueVelocityNorth=avgTrueVelocityNorth,
+                                directionMadeGood=directionMadeGood,
+                                firstLatitude=firstLatitude,
+                                firstLongitude=firstLongitude,
+                                firstTime=firstTime,
+                                lastLatitude=lastLatitude,
+                                lastLongitude=lastLongitude,
+                                lastTime=lastTime,
+                                numberOfHeadingSamplesAveraged=numberOfHeadingSamplesAveraged,
+                                numberOfMagneticTrackSamplesAveraged=numberOfMagneticTrackSamplesAveraged,
+                                numberOfPitchRollSamplesAveraged=numberOfPitchRollSamplesAveraged,
+                                numberOfSpeedSamplesAveraged=numberOfSpeedSamplesAveraged,
+                                numberOfTrueTrackSamplesAveraged=numberOfTrueTrackSamplesAveraged,
+                                primaryFlags=primaryFlags,
+                                shipHeading=shipHeading,
+                                shipPitch=shipPitch,
+                                shipRoll=shipRoll,
+                                speedMadeGood=speedMadeGood,
+                                speedMadeGoodEast=speedMadeGoodEast,
+                                speedMadeGoodNorth=speedMadeGoodNorth)
+           } else if (!bFound && isVMDAS) {
+               oceDebug(debug, "creating data slot for a file with !bFound&&isVMDAS\n")
+               res@data <- list(v=v, q=q, a=a, g=g,
                                 distance=seq(bin1Distance, by=cellSize, length.out=numberOfCells),
                                 time=time,
                                 pressure=pressure,

--- a/man/read.adp.rdi.Rd
+++ b/man/read.adp.rdi.Rd
@@ -114,7 +114,7 @@ about 2e6 bytes [3].  Since R routinely duplicates objects for certain tasks
 (e.g. for call-by-value in function evaluation), \code{read.adp.rdi} uses a safety
 factor in its calculation of when to auto-decimate a file. This factor is set to 3,
 based partly on the developers' experience with datasets in their possession.
-Multiplied by the previously stated safety factor of 3, 
+Multiplied by the previously stated safety factor of 3,
 this suggests that the 2 GB limit on R objects corresponds to approximately a
 222 MB limit on file size. In the present version of \code{read.adp.rdi}, this
 value is lowered to 200 MB for simplicity. Larger files are considered to be "big",
@@ -123,7 +123,7 @@ and are decimated unless the user supplies a value for the \code{by} argument.
 The decimation procedure has two cases.
 \enumerate{
 \item \emph{Case 1.} If \code{from=1} and
-\code{to=0} (or if neither \code{from} or \code{to} is given), then the 
+\code{to=0} (or if neither \code{from} or \code{to} is given), then the
 intention is to process the full span of the data.  If the input file is
 under 200 MB, then \code{by} defaults to 1, so that all profiles are read.
 For larger files, \code{by} is set to the \code{\link{ceiling}} of the


### PR DESCRIPTION
This was occuring for VMDAS files that didn't have bottom track -- basically, it was being missed as a "case" in setting up the data slot and none of the Nav data was getting saved to the object.

I know I didn't open an issue, but the debugging that led to this very simple fix involved a colleague and a set of VMDAS personal data files. I'm pretty confident in the fix though, so I'm just going to go ahead and merge (could have just pushed to develop, but then I couldn't leave a record with comments like this).