### PR TITLE
EAC: bug fix

### DIFF
--- a/R/adp.R
+++ b/R/adp.R
@@ -2114,8 +2114,8 @@ setMethod(f="plot",
                               max.bin <- dim(x@data$v)[2]
                               if (control$bin > max.bin)
                                   stop("cannot have control$bin larger than ", max.bin, " but got ", control$bin)
-                              u <- U[, control$bin, 1]
-                              v <- V[, control$bin, 2]
+                              u <- U[, control$bin] #EAC: bug fix, attempt to subset 2D matrix by 3 dimensions
+                              v <- V[, control$bin]
                           } else {
                               if (x@metadata$numberOfCells > 1) {
                                   u <- apply(U, 1, mean, na.rm=TRUE)


### PR DESCRIPTION
`plot(adp, which= 23, control = list('bin' = n)` , where n is any number

was throwing an error 
```
Error in U[, control$bin, 1] : incorrect number of dimensions
```
I believe this was due to U being set as a 2 dimensional matrix and then being subset as a three dimensional array. I have updated so that U is subset as a two dimensional matrix instead. 

I did a quick search through adp.R for other occurrences of this issue but found none, although there may be ramifications of this change I am not aware of. 

I also wasn't sure if I should identify what I changed in the code, if not feel free to delete the comment within adp.R!


Thanks!