### PR TITLE
fix case where pAtm value is empty

### DIFF
--- a/R/rsk.R
+++ b/R/rsk.R
@@ -742,6 +742,11 @@ read.rsk <- function(file, from=1, to, by=1, type, tz=getOption("oceTz", default
         }, silent=TRUE)
         if (warn)
             warning("non-standard pressureAtmospheric value: ", pressureAtmospheric)
+        ## some cases can have an empty pressureAtmospheric
+        if (length(pressureAtmospheric) == 0) {
+            warning("empty pressureAtmospheric value in rsk file. Setting to default value of 10.1325")
+            pressureAtmospheric <- 10.1325
+            }
         ##message("NEW: pressureAtmospheric:", pressureAtmospheric)
         oceDebug(debug, "after studying the RSK file, now have pressureAtmospheric=", pressureAtmospheric, "\n")
 


### PR DESCRIPTION
This fix was to handle a file (see below, but remove the `.txt` extension) that seemed to have an empty pAtm. I'm not sure if this was unique to this file, or perhaps more common to the "skinny" format RSK which is what you get when you use the mobile App rather than the Desktop one. I know there are some other differences ... a bigger task might be to consult the RSK schema (ha!) to sort out how to handle the two file types separately.

[066092_20181018_1335.rsk.txt](https://github.com/dankelley/oce/files/2569013/066092_20181018_1335.rsk.txt)

