### PR TITLE
fix colormap error preventing zcol values when using x0/x1/col0/col1

### DIFF
--- a/R/colors.R
+++ b/R/colors.R
@@ -687,15 +687,13 @@ colormap <- function(z=NULL,
         } else {
             zcol <- "black"
         }
-        if (missing(missingColor))
-            missingColor <- "gray"
         res <- list(x0=x0, x1=x1, col0=col0, col1=col1,
                      missingColor=missingColor,
                      zclip=FALSE,
                      zlim=if (!missing(zlim)) zlim else range(breaks),
                      breaks=breaks,
                      col=col,
-                     zcol="black")
+                     zcol=zcol)
         class(res) <- c("list", "colormap")
         return(res)
     }


### PR DESCRIPTION
Fixes a bug in the colormap function where zcol is assigned "black" no matter whether `z` was provided or not. Also removes two redundant lines.