### PR TITLE
add despike argument to subtractBottomVelocity

### DIFF
--- a/R/adp.R
+++ b/R/adp.R
@@ -3788,7 +3788,8 @@ display.bytes <- function(b, label="", ...)
 #'
 #' @param x an [adp-class] object that contains bottom-tracking velocities.
 #'
-#' @param despike boolean that indicates if the bottom velocities should be despiked
+#' @param despike a logical value that indicates whether each velocity beam
+#' should be despiked separately, with the matching bv value, using [despike()].
 #'
 #' @template debugTemplate
 #'

--- a/R/adp.R
+++ b/R/adp.R
@@ -3788,6 +3788,8 @@ display.bytes <- function(b, label="", ...)
 #'
 #' @param x an [adp-class] object that contains bottom-tracking velocities.
 #'
+#' @param despike boolean that indicates if the bottom velocities should be despiked
+#'
 #' @template debugTemplate
 #'
 #' @author Dan Kelley and Clark Richards
@@ -3797,7 +3799,7 @@ display.bytes <- function(b, label="", ...)
 #' object class.
 #'
 #' @family things related to adp data
-subtractBottomVelocity <- function(x, debug=getOption("oceDebug"))
+subtractBottomVelocity <- function(x, despike=FALSE, debug=getOption("oceDebug"))
 {
     oceDebug(debug, "subtractBottomVelocity(x) {\n", unindent=1)
     if (!("bv" %in% names(x@data))) {
@@ -3808,7 +3810,11 @@ subtractBottomVelocity <- function(x, debug=getOption("oceDebug"))
     numberOfBeams <- dim(x[["v"]])[3] # could also get from metadata but this is less brittle
     for (beam in 1:numberOfBeams) {
         oceDebug(debug, "beam #", beam, "\n")
-        res@data$v[, , beam] <- x[["v"]][, , beam] - x@data$bv[, beam]
+        if (despike == FALSE) {
+            res@data$v[, , beam] <- x[["v"]][, , beam] - x@data$bv[, beam]
+        } else {
+            res@data$v[, , beam] <- x[["v"]][, , beam] - despike(x@data$bv[, beam])
+        }
     }
     oceDebug(debug, "} # subtractBottomVelocity()\n", unindent=1)
     res@processingLog <- processingLogAppend(res@processingLog, paste(deparse(expr=match.call()), sep="", collapse=""))

--- a/man/subtractBottomVelocity.Rd
+++ b/man/subtractBottomVelocity.Rd
@@ -4,10 +4,12 @@
 \alias{subtractBottomVelocity}
 \title{Subtract Bottom Velocity from ADP}
 \usage{
-subtractBottomVelocity(x, debug = getOption("oceDebug"))
+subtractBottomVelocity(x, despike = FALSE, debug = getOption("oceDebug"))
 }
 \arguments{
 \item{x}{an \linkS4class{adp} object that contains bottom-tracking velocities.}
+
+\item{despike}{boolean that indicates if the bottom velocities should be despiked}
 
 \item{debug}{an integer specifying whether debugging information is
 to be printed during the processing. This is a general parameter that

--- a/man/subtractBottomVelocity.Rd
+++ b/man/subtractBottomVelocity.Rd
@@ -9,7 +9,8 @@ subtractBottomVelocity(x, despike = FALSE, debug = getOption("oceDebug"))
 \arguments{
 \item{x}{an \linkS4class{adp} object that contains bottom-tracking velocities.}
 
-\item{despike}{boolean that indicates if the bottom velocities should be despiked}
+\item{despike}{a logical value that indicates whether each velocity beam
+should be despiked separately, with the matching bv value, using \code{\link[=despike]{despike()}}.}
 
 \item{debug}{an integer specifying whether debugging information is
 to be printed during the processing. This is a general parameter that


### PR DESCRIPTION
Hi everyone,

Essentially my main objective with https://github.com/dankelley/oce/issues/1832  was to have an adp object that included despiked bottom velocities, which is especially important for ship-based adp's and analyzing east, north, and vertical velocities. My solution to this was to change ~ 4 lines of code in the `subtractBottomVelocity` function. My most recent PR adds a boolean despike argument to `subtractBottomVelocity`. If despike = FALSE (by default), the function works exactly how it used to. However, if despike=TRUE, the bottom velocities get despiked before removing them from the beam velocity. The user then has the ability to do what ever they want with that adp object, and we don't have to get into changing multiple plot types.

The significance of this change is shown below where the top plot is with despike=FALSE, and the bottom is with despike=TRUE:
```R
library(oce)
data("coastlineWorld")
files <- list.files(pattern="^COR.*ENS$")
ADCP <- lapply(files, read.adp)
enu <- lapply(ADCP, toEnu)
subtract1 <- subtractBottomVelocity(enu[[1]])
subtract2 <- subtractBottomVelocity(enu[[1]], despike=TRUE)
par(mfrow=c(2,1))
plot(subtract1, which=1)
plot(subtract2, which=1)
```
![Screen Shot 2021-05-19 at 8 24 31 AM](https://user-images.githubusercontent.com/58750538/118804928-b0b3e580-b87b-11eb-97cc-bc4a94e4e60e.png)

Clark, you initially brought the idea of "despiking" bottom velocities to my attention. Do you  (and the rest of the team) believe that this is a good fix?

