### PR TITLE
Update link to WOCE manual Chapter 4

### DIFF
--- a/R/ctd.woce.R
+++ b/R/ctd.woce.R
@@ -14,8 +14,7 @@
 #'
 #' @references
 #' Several online sources list WHP names. An example is
-#' `https://geo.h2o.ucsd.edu/documentation/manuals/pdf/90_1/chap4.pdf`
-#' (a link that was noticed to be failing on May 31, 2020).
+#' `https://cchdo.github.io/hdo-assets/documentation/manuals/pdf/90_1/chap4.pdf`
 #'
 #' @family things related to ctd data
 #' @family functions that interpret variable names and units from headers
@@ -67,8 +66,7 @@ oceNames2whpNames <- function(names)
 #'
 #' @references
 #' Several online sources list WOCE names. An example is
-#' `https://geo.h2o.ucsd.edu/documentation/manuals/pdf/90_1/chap4.pdf`
-#' (a link that was noticed to be failing on May 31, 2020).
+#' `https://cchdo.github.io/hdo-assets/documentation/manuals/pdf/90_1/chap4.pdf`
 #'
 #' @family things related to ctd data
 #' @family functions that interpret variable names and units from headers
@@ -149,8 +147,7 @@ oceUnits2whpUnits <- function(units, scales)
 #'
 #' @references
 #' Several online sources list WOCE names. An example is
-#' `https://geo.h2o.ucsd.edu/documentation/manuals/pdf/90_1/chap4.pdf`
-#' (a link that was noticed to be failing on May 31, 2020).
+#' `https://cchdo.github.io/hdo-assets/documentation/manuals/pdf/90_1/chap4.pdf`
 #'
 #' @family things related to ctd data
 #' @family functions that interpret variable names and units from headers


### PR DESCRIPTION
This updates the link location to chapter 4 of the old WOCE manual to the new location.

I ignored the contents of both `man/` and `docs/` under the assumption that they are generated from the R source. I can update the PR if this is incorrect.

This should Close #1856 