### PR TITLE
fix nortek ad2cp issue with heading being read as int when should be uint

### DIFF
--- a/R/adp.nortek.R
+++ b/R/adp.nortek.R
@@ -813,7 +813,7 @@ read.adp.ad2cp <- function(file, from=1, to=0, by=1, tz=getOption("oceTz"),
     soundSpeed <- 0.1 * readBin(d$buf[pointer2 + 17], "integer", size=2, n=N, signed=FALSE, endian="little")
     temperature <- 0.01 * readBin(d$buf[pointer2 + 19], "integer", size=2, n=N, signed=FALSE, endian="little")
     pressure <- 0.001 * readBin(d$buf[pointer2 + 21], "integer", size=2, n=N, signed=FALSE, endian="little")
-    heading <- 0.01 * readBin(d$buf[pointer2 + 25], "integer", size=2, n=N, endian="little")
+    heading <- 0.01 * readBin(d$buf[pointer2 + 25], "integer", size=2, n=N, signed=FALSE, endian="little")
     pitch <- 0.01 * readBin(d$buf[pointer2 + 27], "integer", size=2, n=N, endian="little")
     roll <- 0.01 * readBin(d$buf[pointer2 + 29], "integer", size=2, n=N, endian="little")
     ## BCC (beam, coordinate system, and cell) uses packed bits to hold info on


### PR DESCRIPTION
Description in title and easily seen in the diff. Heading for an ad2cp was being read as a *signed* int when it should be *unsigned*. I've attached the Nortek integrators guide below, see page 81 for the byte specifications.

I've also attached a test file (needs to be unzipped) from a compass calibration.

[N3015-007_Integrators-Guide-AD2CP_0322.pdf](https://github.com/dankelley/oce/files/8445459/N3015-007_Integrators-Guide-AD2CP_0322.pdf)

[S102791A000_20220405T144049.ad2cp.zip](https://github.com/dankelley/oce/files/8445497/S102791A000_20220405T144049.ad2cp.zip)

