### PR TITLE
issue 2041

### DIFF
--- a/R/adp.R
+++ b/R/adp.R
@@ -4342,7 +4342,11 @@ adpConvertRawToNumeric <- function(object=NULL, variables=NULL, debug=getOption(
 #' This works by fitting a smoothing spline to a bottom range with a defined
 #' number of degrees of freedom. For each time, it then searches to determine
 #' which associated distances are greater than the predicted smooth spline
-#' multiplied by \eqn{1-trim}.
+#' multiplied by `trim`. `trim` comes from the equation
+#' \eqn{cos(beamAngle*pi/180)} where beamAngle is the angle of the beams,
+#' and can sometimes be found by `x[["beamAngle"]]`. This means, if the
+#' beamAngle is known, an appropriate `trim` argument would be equal to
+#' \eqn{cos(beamAngle*pi/180)}.
 #'
 #' @param x an [adp-class] object containing bottom ranges.
 #'
@@ -4365,7 +4369,7 @@ adpConvertRawToNumeric <- function(object=NULL, variables=NULL, debug=getOption(
 #' @family things related to adp data
 #'
 #' @export
-adpFlagPastBoundary <- function(x=NULL, fields=NULL, df=20, trim=0.15, good=1, bad=4, debug=getOption("oceDebug"))
+adpFlagPastBoundary <- function(x=NULL, fields=NULL, df=20, trim=0.06, good=1, bad=4, debug=getOption("oceDebug"))
 {
     oceDebug(debug, "adpFlagPastBoundary() {\n", sep="", unindent=1, style="bold")
     if (!inherits(x, "adp")) {
@@ -4396,7 +4400,7 @@ adpFlagPastBoundary <- function(x=NULL, fields=NULL, df=20, trim=0.15, good=1, b
         s <- smooth.spline(X, y, df=df)
         p <- predict(s, timeSeconds)$y
         for (itime in seq_along(x[["time"]])) {
-            jbad <- x[["distance"]] > (1-trim)*p[itime]
+            jbad <- x[["distance"]] > (trim)*p[itime]
             mask[itime, jbad, kbeam] <- bad
         }
     }

--- a/man/adpFlagPastBoundary.Rd
+++ b/man/adpFlagPastBoundary.Rd
@@ -8,7 +8,7 @@ adpFlagPastBoundary(
   x = NULL,
   fields = NULL,
   df = 20,
-  trim = 0.15,
+  trim = 0.06,
   good = 1,
   bad = 4,
   debug = getOption("oceDebug")
@@ -50,7 +50,11 @@ then be used to remove such data.
 This works by fitting a smoothing spline to a bottom range with a defined
 number of degrees of freedom. For each time, it then searches to determine
 which associated distances are greater than the predicted smooth spline
-multiplied by \eqn{1-trim}.
+multiplied by \code{trim}. \code{trim} comes from the equation
+\eqn{cos(beamAngle*pi/180)} where beamAngle is the angle of the beams,
+and can sometimes be found by \code{x[["beamAngle"]]}. This means, if the
+beamAngle is known, an appropriate \code{trim} argument would be equal to
+\eqn{cos(beamAngle*pi/180)}.
 }
 \seealso{
 Other things related to adp data: 


### PR DESCRIPTION
This updates the documentation for the `adpFlagPastBoundary()`. It also makes a slight change to the function, where instead of having `1-trim` it just has `trim`. This is documented to explain `trim` is equal to `cos(beamAngle*pi/180)`. I tested this and as you can see it would as would be expected.

![flag](https://user-images.githubusercontent.com/58750538/219101274-465d54ca-0870-4f88-a7f5-20abc55c4818.png)
