### PR TITLE
Add new models to swSoundAbsorption function

### DIFF
--- a/R/sw.R
+++ b/R/sw.R
@@ -2552,7 +2552,7 @@ swSigma4 <- function(
 #' @param frequency The frequency of sound, in Hz.
 #'
 #' @param formulation character string indicating the formulation to use, either
-#' of `"fischer-simmons"` or `"francois-garrison"`; see \dQuote{References}.
+#' of `"fischer-simmons"`, `"francois-garrison"`, `"ainslie-mccolm"`, `"schulkin-marsh"` or `"thorp"`; see \dQuote{References}.
 #'
 #' @param pH seawater pH
 #'
@@ -2570,6 +2570,12 @@ swSigma4 <- function(
 #'
 #' 3. `http://resource.npl.co.uk/acoustics/techguides/seaabsorption/`
 #'
+#' 4. Michael A. Ainslie, James G. McColm; A simplified formula for viscous and chemical 
+#' absorption in sea water. J. Acoust. Soc. Am. 1 March 1998; 103 (3): 1671–1672. 
+#' 
+#' 5. M. Schulkin, H. W. Marsh; Sound Absorption in Sea Water. 
+#' J. Acoust. Soc. Am. 1 June 1962; 34 (6): 864–865.
+#' 
 #' @examples
 #' # Fisher & Simmons (1977 table IV) gives 0.52 dB/km for 35 PSU, 5 degC, 500 atm
 #' # (4990 dbar of water)a and 10 kHz
@@ -2586,10 +2592,11 @@ swSigma4 <- function(
 #' @family functions that calculate seawater properties
 swSoundAbsorption <- function(
     frequency, salinity, temperature, pressure, pH = 8,
-    formulation = c("fisher-simmons", "francois-garrison")) {
+    formulation = c("fisher-simmons", "francois-garrison", "ainslie-mccolm", "schulkin-marsh", "thorp")) {
     formulation <- match.arg(formulation)
     # nolint start T_and_F_symbol_linter
     if (formulation == "fisher-simmons") {
+        print("fisher-simmons")
         # Equation numbers are from Fisher & Simmons (1977); see help page for ref
         p <- 1 + pressure / 10 # add atmophere, then convert water part from dbar
         S <- salinity
@@ -2605,6 +2612,7 @@ swSoundAbsorption <- function(
         alpha <- (A1 * f1 * f^2) / (f1^2 + f^2) + (A2 * P2 * f2 * f^2) / (f2^2 + f^2) + A3 * P3 * f^2 # (3a)
         alpha <- alpha * 8686 / 1000 # dB/m
     } else if (formulation == "francois-garrison") {
+        print("francois-garrison")
         S <- salinity
         T <- T68fromT90(temperature)
         D <- pressure # FIXME: approximation
@@ -2631,6 +2639,42 @@ swSoundAbsorption <- function(
         P3 <- 1 - 3.83e-5 * D + 4.9e-10 * D^2
         alpha <- (A1 * P1 * f1 * f^2) / (f^2 + f1^2) + (A2 * P2 * f2 * f^2) / (f^2 + f2^2) + A3 * P3 * f^2
         alpha <- alpha / 1000
+    }else if (formulation == "ainslie-mccolm") {
+        print("ainslie-mccolm")
+        # Equation numbers are from Ainslie & McColm Model (1998); see help page for ref
+        S <- salinity
+        T <- T68fromT90(temperature)
+        D <- pressure/1000 # FIXME: approximation; D in km
+        f <- frequency / 1000 # convert to kHz
+        # f1 in kHz
+        f1 <- 0.78 * sqrt(S / 35) * exp(T / 26) # (1) - boric acid contribution
+        # f2 in kHz
+        f2 <- 42 * exp(T/17) # (2) - magnesium contribution
+        alpha <-  0.106 * ( (f1 * f^2) / (f^2 + f1^2) ) * exp( (pH - 8)/0.56 ) + 0.52 * (1 + (T/43)) * (S/35) * (f2 * f^2 / (f^2 + f2^2)) * exp(-D/6) + 0.00049 * (f^2) * exp(-( (T/27) + (D/17) )) # (3)
+        alpha <- alpha / 1000 # dB/km to dB/m
+    }else if (formulation == "schulkin-marsh") {
+        print("schulkin-marsh")
+        # Equation numbers are from schulkin-marsh Model (1962); see help page for ref
+        S <- salinity
+        T <- T68fromT90(temperature)
+        D <- pressure # FIXME: approximation; D in m
+        f <- frequency / 1000 # convert to kHz
+        A <- 2.34e-6
+        B <- 3.38e-6
+        ft <- 21.9 * 10^(6-(1520/(T+273)))
+        P <- ( 1034 + (9.81 * D) + 101.325 ) * 1.02e-5 # 1 Pa (N/m2) = 1.02×10-5 kg/cm2 | Atmospheric Pressure: (1 atm or 101,325 pascals)
+        alpha <- 8.68e3 * (((S*A*ft*(f^2))/((ft^2)+(f^2))) + (B*f^2/ft)) * (1 - (6.54e-4)*P) # (9) - 1 nepers/metre = 8.68*10**3 dB/Km
+        alpha <- alpha / 1000 # dB/km to dB/m
+    }else if (formulation == "thorp") {
+        print("thorp")
+        # Equation numbers are from thorp Model (xxxx); see help page for ref
+        S <- salinity
+        T <- T68fromT90(temperature)
+        f <- frequency / 1000 # convert to kHz
+        f1 <- 0.78 * sqrt(S / 35) * exp(T/26)
+        f2 <- 42 * exp(T/17)
+        alpha <- 0.11 * ((f^2) / (1 + f^2)) + 44 * (f^2 / (4100 + f^2)) + (2.75e-4)*f^2 + 0.003
+        alpha <- alpha / 1000 # dB/km to dB/m
     }
     # nolint end T_and_F_symbol_linter
     alpha

--- a/R/sw.R
+++ b/R/sw.R
@@ -2623,7 +2623,11 @@ swSoundAbsorption <- function(
         # f2 in kHz
         f2 <- (8.17 * 10^(8 - 1990 / theta)) / (1 + 0.0018 * (S - 35)) # nolint (space before left parenthesis)
         # pure water contribution
-        A3 <- 3.964e-4 - 1.146e-5 * T + 1.45e-7 * T^2 - 6.5e-10 * T^3 # dB / km / kHz^2
+        if (T <= 20) {
+          A3 <- 4.937e-4 - 2.59e-5 * T + 9.11e-7 * T^2 - 1.50e-8 * T^3
+        } else {
+          A3 <- 3.964e-4 - 1.146e-5 * T + 1.45e-7 * T^2 - 6.5e-10 * T^3
+        }
         P3 <- 1 - 3.83e-5 * D + 4.9e-10 * D^2
         alpha <- (A1 * P1 * f1 * f^2) / (f^2 + f1^2) + (A2 * P2 * f2 * f^2) / (f^2 + f2^2) + A3 * P3 * f^2
         alpha <- alpha / 1000

--- a/R/sw.R
+++ b/R/sw.R
@@ -2576,6 +2576,13 @@ swSigma4 <- function(
 #' 5. M. Schulkin, H. W. Marsh; Sound Absorption in Sea Water. 
 #' J. Acoust. Soc. Am. 1 June 1962; 34 (6): 864–865.
 #' 
+#' 6. . H. Thorp. Analytic description of the low frequency attenuation coefficient. Journal 
+#' of Acoustical Society of America, 1967.
+#' 
+#' 7. T. Melodia, H. Kulhandjian, L.-C. Kuo, and E. Demirors, "Advances in underwater acoustic networking," Mobile
+#' Ad Hoc Networking: Cutting Edge Directions, pp. 804-852, 2013.
+#' 
+#' 
 #' @examples
 #' # Fisher & Simmons (1977 table IV) gives 0.52 dB/km for 35 PSU, 5 degC, 500 atm
 #' # (4990 dbar of water)a and 10 kHz
@@ -2622,7 +2629,6 @@ swSoundAbsorption <- function(
         alpha <- (A1 * f1 * f^2) / (f1^2 + f^2) + (A2 * P2 * f2 * f^2) / (f2^2 + f^2) + A3 * P3 * f^2 # (3a)
         alpha <- alpha * 8686 / 1000 # dB/m
     } else if (formulation == "francois-garrison") {
-        print("francois-garrison")
         S <- salinity
         T <- T68fromT90(temperature)
         D <- pressure # FIXME: approximation
@@ -2650,20 +2656,18 @@ swSoundAbsorption <- function(
         alpha <- (A1 * P1 * f1 * f^2) / (f^2 + f1^2) + (A2 * P2 * f2 * f^2) / (f^2 + f2^2) + A3 * P3 * f^2
         alpha <- alpha / 1000
     }else if (formulation == "ainslie-mccolm") {
-        print("ainslie-mccolm")
         # Equation numbers are from Ainslie & McColm Model (1998); see help page for ref
         S <- salinity
         T <- T68fromT90(temperature)
         D <- pressure/1000 # FIXME: approximation; D in km
         f <- frequency / 1000 # convert to kHz
         # f1 in kHz
-        f1 <- 0.78 * sqrt(S / 35) * exp(T / 26) # (1) - boric acid contribution
+        f1 <- 0.78 * sqrt(S / 35) * exp(T / 26) # (1)
         # f2 in kHz
-        f2 <- 42 * exp(T/17) # (2) - magnesium contribution
+        f2 <- 42 * exp(T/17) # (2)
         alpha <-  0.106 * ( (f1 * f^2) / (f^2 + f1^2) ) * exp( (pH - 8)/0.56 ) + 0.52 * (1 + (T/43)) * (S/35) * (f2 * f^2 / (f^2 + f2^2)) * exp(-D/6) + 0.00049 * (f^2) * exp(-( (T/27) + (D/17) )) # (3)
         alpha <- alpha / 1000 # dB/km to dB/m
     }else if (formulation == "schulkin-marsh") {
-        print("schulkin-marsh")
         # Equation numbers are from schulkin-marsh Model (1962); see help page for ref
         S <- salinity
         T <- T68fromT90(temperature)
@@ -2675,15 +2679,27 @@ swSoundAbsorption <- function(
         P <- ( 1034 + (9.81 * D) + 101.325 ) * 1.02e-5 # 1 Pa (N/m2) = 1.02×10-5 kg/cm2 | Atmospheric Pressure: (1 atm or 101,325 pascals)
         alpha <- 8.68e3 * (((S*A*ft*(f^2))/((ft^2)+(f^2))) + (B*f^2/ft)) * (1 - (6.54e-4)*P) # (9) - 1 nepers/metre = 8.68*10**3 dB/Km
         alpha <- alpha / 1000 # dB/km to dB/m
-    }else if (formulation == "thorp") {
-        print("thorp")
-        # Equation numbers are from thorp Model (xxxx); see help page for ref
+    }else if (formulation == "thorp-extended") {
+        # Equation numbers refer to "Advances in Underwater Acoustic Networking"; see help page for ref
+        # This equation is an extended version of Thorp's equation, as referenced in the sources below:
+        #
+        # 1. Al-Aboosi, Yasin & Al-Aboosi, Jenan. (2018). Study of Absorption Loss Effects on Acoustic Wave Propagation 
+        # in Shallow Water Using Different Empirical Models. International Journal of Advances in Applied Sciences.
+        #
+        # 2. Milica Stojanovic. 2006. On the relationship between capacity and distance in an underwater acoustic communication channel. 
+        # In Proceedings of the 1st International Workshop on Underwater Networks (WUWNet '06). Association for Computing Machinery.
+        #
+        # 3. A. Sehgal, I. Tumar and J. Schonwalder, "Variability of available capacity due to the effects of depth and temperature in the 
+        # underwater acoustic communication channel," OCEANS 2009-EUROPE, Bremen, Germany, 2009.
+        #
+        # Note:
+        # 1. Following the citations will lead to Thorp's original paper, which does NOT include the last two terms.
+        # 2. The coefficients in the first two terms differ from those in Thorp's original paper due to unit conversion 
+        #    from dB/kyd to dB/km.
         S <- salinity
         T <- T68fromT90(temperature)
         f <- frequency / 1000 # convert to kHz
-        f1 <- 0.78 * sqrt(S / 35) * exp(T/26)
-        f2 <- 42 * exp(T/17)
-        alpha <- 0.11 * ((f^2) / (1 + f^2)) + 44 * (f^2 / (4100 + f^2)) + (2.75e-4)*f^2 + 0.003
+        alpha <- 0.11 * ((f^2) / (1 + f^2)) + 44 * (f^2 / (4100 + f^2)) + (2.75e-4)*f^2 + 0.003 # (23.2)
         alpha <- alpha / 1000 # dB/km to dB/m
     }
     # nolint end T_and_F_symbol_linter

--- a/R/sw.R
+++ b/R/sw.R
@@ -2586,9 +2586,19 @@ swSigma4 <- function(
 #' plot(f / 1000, 1e3 * swSoundAbsorption(f, 35, 10, 0, formulation = "fr"),
 #'     xlab = " Freq [kHz]", ylab = " dB/km", type = "l", log = "xy"
 #' )
-#' lines(f / 1000, 1e3 * swSoundAbsorption(f, 0, 10, 0, formulation = "fr"), lty = "dashed")
+#' lines(f / 1000, 1e3 * swSoundAbsorption(f, 0, 10, 0, formulation = "fr"), lty = "solid")
 #' legend("topleft", lty = c("solid", "dashed"), legend = c("S=35", "S=0"))
 #'
+#' # reproduce a comparison plot between the existing absorption models
+#' f <- 1e3 * 10^(seq(-1, 3, 0.1))
+#' plot(f / 1000, 1e3 * swSoundAbsorption(f, 35, 10, 1000, formulation = "fi"), xlab = " Freq [kHz]", ylab = " dB/km", type = "l", col="blue")
+#' lines(f / 1000, 1e3 * swSoundAbsorption(f, 35, 10, 1000, formulation = "fr"), lty = "solid", col="red")
+#' lines(f / 1000, 1e3 * swSoundAbsorption(f, 35, 10, 1000, formulation = "ai"), lty = "solid", col="green")
+#' lines(f / 1000, 1e3 * swSoundAbsorption(f, 35, 10, 1000, formulation = "sc"), lty = "solid", col="purple")
+#' lines(f / 1000, 1e3 * swSoundAbsorption(f, 35, 10, 1000, formulation = "th"), lty = "solid", col="yellow")
+#' legend("topleft", legend = c("fisher-simmons", "francois-garrison", "ainslie-mccolm", "schulkin-marsh", "thorp"), col = c("blue", "red", "green", "purple", "yellow"), lty = 1, lwd = 2)
+#' title("Comparison of sound absorption models")
+#' 
 #' @family functions that calculate seawater properties
 swSoundAbsorption <- function(
     frequency, salinity, temperature, pressure, pH = 8,

--- a/R/sw.R
+++ b/R/sw.R
@@ -2546,13 +2546,25 @@ swSigma4 <- function(
 #' shown in reference 3 for example.  For this reason, it is likely that more
 #' formulations will be added to this function, and entirely possible that the
 #' default may change.
+#' 
+#' @note Regarding the `"thorp-extended"` model, the equation was obtained from \[7\].
+#' This equation is an extended version of Thorp's equation, as referenced in the sources below:
+#' 1. Al-Aboosi, Yasin & Al-Aboosi, Jenan. (2018). Study of Absorption Loss Effects on Acoustic Wave Propagation 
+#' in Shallow Water Using Different Empirical Models. International Journal of Advances in Applied Sciences.
+#' 2. Milica Stojanovic. 2006. On the relationship between capacity and distance in an underwater acoustic communication channel. 
+#' In Proceedings of the 1st International Workshop on Underwater Networks (WUWNet '06). Association for Computing Machinery.
+#' 3. A. Sehgal, I. Tumar and J. Schonwalder, "Variability of available capacity due to the effects of depth and temperature in the 
+#' underwater acoustic communication channel," OCEANS 2009-EUROPE, Bremen, Germany, 2009.
 #'
+#' Following the citations will lead to Thorp's original paper, which does not include the extended equation. The original source for
+#' this extended version is not clear. 
+#' 
 #' @inheritParams swRho
 #'
 #' @param frequency The frequency of sound, in Hz.
 #'
 #' @param formulation character string indicating the formulation to use, either
-#' of `"fischer-simmons"`, `"francois-garrison"`, `"ainslie-mccolm"`, `"schulkin-marsh"` or `"thorp"`; see \dQuote{References}.
+#' of `"fischer-simmons"`, `"francois-garrison"`, `"ainslie-mccolm"`, `"schulkin-marsh"` or `"thorp-extended"`; see \dQuote{References}.
 #'
 #' @param pH seawater pH
 #'
@@ -2576,7 +2588,7 @@ swSigma4 <- function(
 #' 5. M. Schulkin, H. W. Marsh; Sound Absorption in Sea Water. 
 #' J. Acoust. Soc. Am. 1 June 1962; 34 (6): 864–865.
 #' 
-#' 6. . H. Thorp. Analytic description of the low frequency attenuation coefficient. Journal 
+#' 6. H. Thorp. Analytic description of the low frequency attenuation coefficient. Journal 
 #' of Acoustical Society of America, 1967.
 #' 
 #' 7. T. Melodia, H. Kulhandjian, L.-C. Kuo, and E. Demirors, "Advances in underwater acoustic networking," Mobile
@@ -2589,31 +2601,30 @@ swSigma4 <- function(
 #' alpha <- swSoundAbsorption(35, 4, 4990, 10e3)
 #'
 #' # reproduce part of Fig 8 of Francois and Garrison (1982 Fig 8)
-#' f <- 1e3 * 10^(seq(-1, 3, 0.1)) # in KHz
+#' f <- 1e3 * 10^(seq(-1, 3, 0.1)) # in Hz
 #' plot(f / 1000, 1e3 * swSoundAbsorption(f, 35, 10, 0, formulation = "fr"),
 #'     xlab = " Freq [kHz]", ylab = " dB/km", type = "l", log = "xy"
 #' )
 #' lines(f / 1000, 1e3 * swSoundAbsorption(f, 0, 10, 0, formulation = "fr"), lty = "solid")
 #' legend("topleft", lty = c("solid", "dashed"), legend = c("S=35", "S=0"))
 #'
-#' # reproduce a comparison plot between the existing absorption models
+#' # Comparison plot between the existing absorption models
 #' f <- 1e3 * 10^(seq(-1, 3, 0.1))
 #' plot(f / 1000, 1e3 * swSoundAbsorption(f, 35, 10, 1000, formulation = "fi"), xlab = " Freq [kHz]", ylab = " dB/km", type = "l", col="blue")
 #' lines(f / 1000, 1e3 * swSoundAbsorption(f, 35, 10, 1000, formulation = "fr"), lty = "solid", col="red")
 #' lines(f / 1000, 1e3 * swSoundAbsorption(f, 35, 10, 1000, formulation = "ai"), lty = "solid", col="green")
 #' lines(f / 1000, 1e3 * swSoundAbsorption(f, 35, 10, 1000, formulation = "sc"), lty = "solid", col="purple")
-#' lines(f / 1000, 1e3 * swSoundAbsorption(f, 35, 10, 1000, formulation = "th"), lty = "solid", col="yellow")
-#' legend("topleft", legend = c("fisher-simmons", "francois-garrison", "ainslie-mccolm", "schulkin-marsh", "thorp"), col = c("blue", "red", "green", "purple", "yellow"), lty = 1, lwd = 2)
+#' lines(f / 1000, 1e3 * swSoundAbsorption(f, 35, 10, 1000, formulation = "th"), lty = "solid", col="black")
+#' legend("topleft", legend = c("fisher-simmons", "francois-garrison", "ainslie-mccolm", "schulkin-marsh", "thorp-extended"), col = c("blue", "red", "green", "purple", "black"), lty = 1, lwd = 2)
 #' title("Comparison of sound absorption models")
 #' 
 #' @family functions that calculate seawater properties
 swSoundAbsorption <- function(
     frequency, salinity, temperature, pressure, pH = 8,
-    formulation = c("fisher-simmons", "francois-garrison", "ainslie-mccolm", "schulkin-marsh", "thorp")) {
+    formulation = c("fisher-simmons", "francois-garrison", "ainslie-mccolm", "schulkin-marsh", "thorp-extended")) {
     formulation <- match.arg(formulation)
     # nolint start T_and_F_symbol_linter
     if (formulation == "fisher-simmons") {
-        print("fisher-simmons")
         # Equation numbers are from Fisher & Simmons (1977); see help page for ref
         p <- 1 + pressure / 10 # add atmophere, then convert water part from dbar
         S <- salinity
@@ -2693,7 +2704,8 @@ swSoundAbsorption <- function(
         # underwater acoustic communication channel," OCEANS 2009-EUROPE, Bremen, Germany, 2009.
         #
         # Note:
-        # 1. Following the citations will lead to Thorp's original paper, which does NOT include the last two terms.
+        # 1. Following the citations will lead to Thorp's original paper, which does not include the last two terms. The original source for
+        # this extended version is not clear. 
         # 2. The coefficients in the first two terms differ from those in Thorp's original paper due to unit conversion 
         #    from dB/kyd to dB/km.
         S <- salinity

--- a/man/swSoundAbsorption.Rd
+++ b/man/swSoundAbsorption.Rd
@@ -10,7 +10,8 @@ swSoundAbsorption(
   temperature,
   pressure,
   pH = 8,
-  formulation = c("fisher-simmons", "francois-garrison")
+  formulation = c("fisher-simmons", "francois-garrison", "ainslie-mccolm",
+    "schulkin-marsh", "thorp-extended")
 )
 }
 \arguments{
@@ -35,7 +36,7 @@ using \code{\link[=T68fromT90]{T68fromT90()}}.}
 \item{pH}{seawater pH}
 
 \item{formulation}{character string indicating the formulation to use, either
-of \code{"fischer-simmons"} or \code{"francois-garrison"}; see \dQuote{References}.}
+of \code{"fischer-simmons"}, \code{"francois-garrison"}, \code{"ainslie-mccolm"}, \code{"schulkin-marsh"} or \code{"thorp-extended"}; see \dQuote{References}.}
 }
 \value{
 Sound absorption in dB/m.
@@ -50,18 +51,43 @@ shown in reference 3 for example.  For this reason, it is likely that more
 formulations will be added to this function, and entirely possible that the
 default may change.
 }
+\note{
+Regarding the \code{"thorp-extended"} model, the equation was obtained from [7].
+This equation is an extended version of Thorp's equation, as referenced in the sources below:
+\enumerate{
+\item Al-Aboosi, Yasin & Al-Aboosi, Jenan. (2018). Study of Absorption Loss Effects on Acoustic Wave Propagation
+in Shallow Water Using Different Empirical Models. International Journal of Advances in Applied Sciences.
+\item Milica Stojanovic. 2006. On the relationship between capacity and distance in an underwater acoustic communication channel.
+In Proceedings of the 1st International Workshop on Underwater Networks (WUWNet '06). Association for Computing Machinery.
+\item A. Sehgal, I. Tumar and J. Schonwalder, "Variability of available capacity due to the effects of depth and temperature in the
+underwater acoustic communication channel," OCEANS 2009-EUROPE, Bremen, Germany, 2009.
+}
+
+Following the citations will lead to Thorp's original paper, which does not include the extended equation. The original source for
+this extended version is not clear.
+}
 \examples{
 # Fisher & Simmons (1977 table IV) gives 0.52 dB/km for 35 PSU, 5 degC, 500 atm
 # (4990 dbar of water)a and 10 kHz
 alpha <- swSoundAbsorption(35, 4, 4990, 10e3)
 
 # reproduce part of Fig 8 of Francois and Garrison (1982 Fig 8)
-f <- 1e3 * 10^(seq(-1, 3, 0.1)) # in KHz
+f <- 1e3 * 10^(seq(-1, 3, 0.1)) # in Hz
 plot(f / 1000, 1e3 * swSoundAbsorption(f, 35, 10, 0, formulation = "fr"),
     xlab = " Freq [kHz]", ylab = " dB/km", type = "l", log = "xy"
 )
-lines(f / 1000, 1e3 * swSoundAbsorption(f, 0, 10, 0, formulation = "fr"), lty = "dashed")
+lines(f / 1000, 1e3 * swSoundAbsorption(f, 0, 10, 0, formulation = "fr"), lty = "solid")
 legend("topleft", lty = c("solid", "dashed"), legend = c("S=35", "S=0"))
+
+# Comparison plot between the existing absorption models
+f <- 1e3 * 10^(seq(-1, 3, 0.1))
+plot(f / 1000, 1e3 * swSoundAbsorption(f, 35, 10, 1000, formulation = "fi"), xlab = " Freq [kHz]", ylab = " dB/km", type = "l", col="blue")
+lines(f / 1000, 1e3 * swSoundAbsorption(f, 35, 10, 1000, formulation = "fr"), lty = "solid", col="red")
+lines(f / 1000, 1e3 * swSoundAbsorption(f, 35, 10, 1000, formulation = "ai"), lty = "solid", col="green")
+lines(f / 1000, 1e3 * swSoundAbsorption(f, 35, 10, 1000, formulation = "sc"), lty = "solid", col="purple")
+lines(f / 1000, 1e3 * swSoundAbsorption(f, 35, 10, 1000, formulation = "th"), lty = "solid", col="black")
+legend("topleft", legend = c("fisher-simmons", "francois-garrison", "ainslie-mccolm", "schulkin-marsh", "thorp-extended"), col = c("blue", "red", "green", "purple", "black"), lty = 1, lwd = 2)
+title("Comparison of sound absorption models")
 
 }
 \references{
@@ -72,6 +98,14 @@ sea water.  Journal of the Acoustical Society of America, 62(3), 558-564.
 ocean measurements.  Part II: Boric acid contribution and equation for total
 absorption.  Journal of the Acoustical Society of America, 72(6):1879-1890.
 \item \verb{http://resource.npl.co.uk/acoustics/techguides/seaabsorption/}
+\item Michael A. Ainslie, James G. McColm; A simplified formula for viscous and chemical
+absorption in sea water. J. Acoust. Soc. Am. 1 March 1998; 103 (3): 1671–1672.
+\item M. Schulkin, H. W. Marsh; Sound Absorption in Sea Water.
+J. Acoust. Soc. Am. 1 June 1962; 34 (6): 864–865.
+\item H. Thorp. Analytic description of the low frequency attenuation coefficient. Journal
+of Acoustical Society of America, 1967.
+\item T. Melodia, H. Kulhandjian, L.-C. Kuo, and E. Demirors, "Advances in underwater acoustic networking," Mobile
+Ad Hoc Networking: Cutting Edge Directions, pp. 804-852, 2013.
 }
 }
 \seealso{


### PR DESCRIPTION
This PR adds the following models to the computation of the sound absorption of seawater in the function swSoundAbsorption():
- Ainslie-McColm
- Schulkin-Marsh
- Thorp-Extended

Fix:
- Add temperature condition in pure water contribution of Francois-Garrison model as stated in the referenced paper

Documentation:
- Add references to new models
- Add a note related to the Thorp-Extended model
- Add an example on how to plot a comparison between models
- Fix incorrect comment in the creation of the frequency array of the first example, where the units are in Hz and not kHz as stated in the comment.

<img width="640" height="638" alt="image" src="https://github.com/user-attachments/assets/d56e2799-61fb-4e77-9e21-370accb13d8d" />

