### PR TITLE
Fix issue #2346 (nc not being closed)

### DIFF
--- a/R/netcdf.R
+++ b/R/netcdf.R
@@ -185,6 +185,7 @@ read.netcdf <- function(file, ..., encoding = NA, renamer = NULL, debug = getOpt
     }
     oceDebug(debug, "read.netcdf() START\n", unindent = 1)
     nc <- ncdf4::nc_open(file)
+    on.exit(ncdf4::nc_close(nc))
     res <- new("oce")
     varNames <- names(nc$var)
     if ("time" %in% names(nc$dim)) {


### PR DESCRIPTION
An easy fix, but I'm not sure if the one `on.exit()` is enough, or if we should also explicity close the nc connection.