### PR TITLE
Issue2639 hadcp

### DIFF
--- a/R/adp.rdi.R
+++ b/R/adp.rdi.R
@@ -1,4 +1,4 @@
-# vim:textwidth=80:expandtab:shiftwidth=4:softtabstop=4
+# vim0textwidth=80:expandtab:shiftwidth=4:softtabstop=4
 
 # byte sequences at start of items
 # FLH 00 00; VLH 00 80; vel 00 01; Cor 00 02;  echo 00 03; percent 00 04; bottom-track 00 06
@@ -283,9 +283,9 @@ decodeHeaderRDI <- function(buf, debug = getOption("oceDebug"), tz = getOption("
     # real.sim.flag <- readBin(FLD[7], "integer", n=1, size=1)
     # lagLength <- readBin(FLD[8], "integer", n=1, size=1, signed=FALSE) # unused
     numberOfBeams <- readBin(FLD[9], "integer", n = 1, size = 1, signed = FALSE)
-    nbeam <- 4 # setting this to use for properly reading p file format (Issue 2639)
+    numberOfBeamsToRead <- 4 # setting this to use for properly reading p file format (Issue 2639)
     if (numberOfBeams == 3) {
-        oceDebug(debug, "3 beam (HADCP) detected, setting nbeam=", nbeam, "\n")
+        oceDebug(debug, "3 beam (HADCP) detected, setting numberOfBeamsToRead=", numberOfBeamsToRead, "\n")
     }
     oceDebug(debug, "numberOfBeams", numberOfBeams, "\n")
     numberOfCells <- abs(readBin(FLD[10], "integer", n = 1, size = 1, signed = FALSE)) # WN
@@ -472,7 +472,7 @@ decodeHeaderRDI <- function(buf, debug = getOption("oceDebug"), tz = getOption("
         dataOffset = dataOffset,
         codes = codes,
         numberOfBeams = numberOfBeams,
-        nbeam = nbeam,
+        numberOfBeamsToRead = numberOfBeamsToRead,
         numberOfCells = numberOfCells,
         pingsPerEnsemble = pingsPerEnsemble,
         cellSize = cellSize,
@@ -546,6 +546,17 @@ decodeHeaderRDI <- function(buf, debug = getOption("oceDebug"), tz = getOption("
 #' RDI documentation that indicates the condition in which this
 #' century offset is required, then a change will be made to the code.
 #' Even if not, the method should not cause problems for a long time.
+#'
+#' @section Handling of 3-beam Horizontal ADCP (HADCP) files
+#'
+#' While most RDI ADCPs contain 4 beams (with the exception of some SentinelV
+#' ADCPs, which stores the vertical beam data in a separate data structure), the
+#' HADCP (which is a discontinued product in 2026) only has 3 beams. Depsite the
+#' fact that there are only 3 beams, the pd0 data file format is still written
+#' as through there are four beams worth of data. The exact meaning of each of
+#' the "beams" in the data file depends on the coordinate system of the
+#' intstrument (e.g. beam, xyz, sfm, or enu), with the RDI data format manual
+#' indicating how to interpret the resulting arrays.
 #'
 #' @template adpTemplate
 #'
@@ -959,7 +970,7 @@ read.adp.rdi <- function(
     oceDebug(debug, "have Binary Fixed Attitude Header: ", header$haveBinaryFixedAttitudeHeader, "\n")
     if (header$haveActualData) {
         numberOfBeams <- header$numberOfBeams
-        nbeam <- header$nbeam
+        numberOfBeamsToRead <- header$numberOfBeamsToRead
         numberOfCells <- header$numberOfCells
         bin1Distance <- header$bin1Distance
         xmitPulseLength <- header$xmitPulseLength
@@ -1137,7 +1148,7 @@ read.adp.rdi <- function(
             oceDebug(debug, "numberOfBeams: ", numberOfBeams, "\n")
             oceDebug(debug, "numberOfCells: ", numberOfCells, "\n")
             # items <- numberOfBeams * numberOfCells
-            items <- nbeam * numberOfCells
+            items <- numberOfBeamsToRead * numberOfCells
             codes <- header$codes
             oceDebug(debug, "codes[,1]=", paste("0x", paste(codes[, 1], sep = ""), collapse = " "), "\n")
             oceDebug(debug, "codes[,2]=", paste("0x", paste(codes[, 2], sep = ""), collapse = " "), "\n")
@@ -1193,40 +1204,40 @@ read.adp.rdi <- function(
             }
             if (vFound) {
                 # v <- array(numeric(), dim = c(profilesToRead, numberOfCells, numberOfBeams))
-                v <- array(numeric(), dim = c(profilesToRead, numberOfCells, nbeam))
+                v <- array(numeric(), dim = c(profilesToRead, numberOfCells, numberOfBeamsToRead))
                 oceDebug(
                     debug, "set up 'v' (velocity) storage for ", profilesToRead, " profiles,",
-                    numberOfCells, " cells, and ", numberOfBeams, " beams\n"
+                    numberOfCells, " cells, and ", numberOfBeamsToRead, " beams\n"
                 )
             } else {
                 v <- NULL
             }
             if (qFound) {
                 # q <- array(raw(), dim = c(profilesToRead, numberOfCells, numberOfBeams))
-                q <- array(raw(), dim = c(profilesToRead, numberOfCells, nbeam))
+                q <- array(raw(), dim = c(profilesToRead, numberOfCells, numberOfBeamsToRead))
                 oceDebug(
                     debug, "set up 'q' (correlation) storage for ", profilesToRead, " profiles, ",
-                    numberOfCells, " cells, and ", numberOfBeams, " beams\n"
+                    numberOfCells, " cells, and ", numberOfBeamsToRead, " beams\n"
                 )
             } else {
                 q <- NULL
             }
             if (aFound) {
                 # a <- array(raw(), dim = c(profilesToRead, numberOfCells, numberOfBeams))
-                a <- array(raw(), dim = c(profilesToRead, numberOfCells, nbeam))
+                a <- array(raw(), dim = c(profilesToRead, numberOfCells, numberOfBeamsToRead))
                 oceDebug(
                     debug, "set up 'a' (echo intensity) storage for ", profilesToRead, " profiles, ",
-                    numberOfCells, " cells, and ", numberOfBeams, " beams\n"
+                    numberOfCells, " cells, and ", numberOfBeamsToRead, " beams\n"
                 )
             } else {
                 a <- NULL
             }
             if (gFound) {
                 # g <- array(raw(), dim = c(profilesToRead, numberOfCells, numberOfBeams))
-                g <- array(raw(), dim = c(profilesToRead, numberOfCells, nbeam))
+                g <- array(raw(), dim = c(profilesToRead, numberOfCells, numberOfBeamsToRead))
                 oceDebug(
                     debug, "set up 'g' (percent good) storage for ", profilesToRead, " profiles, ",
-                    numberOfCells, " cells, and ", numberOfBeams, " beams\n"
+                    numberOfCells, " cells, and ", numberOfBeamsToRead, " beams\n"
                 )
             } else {
                 g <- NULL
@@ -1450,15 +1461,15 @@ read.adp.rdi <- function(
                 # bq <- array(double(), dim = c(profilesToRead, numberOfBeams)) # correlation
                 # ba <- array(double(), dim = c(profilesToRead, numberOfBeams)) # amplitude
                 # bg <- array(double(), dim = c(profilesToRead, numberOfBeams)) # percent good
-                br <- array(double(), dim = c(profilesToRead, nbeam))
-                bv <- array(double(), dim = c(profilesToRead, nbeam))
+                br <- array(double(), dim = c(profilesToRead, numberOfBeamsToRead))
+                bv <- array(double(), dim = c(profilesToRead, numberOfBeamsToRead))
                 # bq called bc until 2023-02-09 https://github.com/dankelley/oce/issues/2039
-                bq <- array(double(), dim = c(profilesToRead, nbeam)) # correlation
-                ba <- array(double(), dim = c(profilesToRead, nbeam)) # amplitude
-                bg <- array(double(), dim = c(profilesToRead, nbeam)) # percent good
+                bq <- array(double(), dim = c(profilesToRead, numberOfBeamsToRead)) # correlation
+                ba <- array(double(), dim = c(profilesToRead, numberOfBeamsToRead)) # amplitude
+                bg <- array(double(), dim = c(profilesToRead, numberOfBeamsToRead)) # percent good
                 oceDebug(
                     debug, "set up 'br', etc. (bottom data) storage for ", profilesToRead, " profiles, ",
-                    numberOfCells, " cells, and ", numberOfBeams, " beams\n"
+                    numberOfCells, " cells, and ", numberOfBeamsToRead, " beams\n"
                 )
             } else {
                 br <- bv <- bq <- ba <- bg <- NULL
@@ -1527,7 +1538,7 @@ read.adp.rdi <- function(
                         vtmp <- readBin(buf[o + 1 + seq(1, 2 * items)], "integer", n = items, size = 2, endian = "little", signed = TRUE)
                         vtmp[-32768 == vtmp] <- NA # blank out bad data
                         # v[i, , ] <- matrix(velocityScale * vtmp, ncol = numberOfBeams, byrow = TRUE)
-                        v[i, , ] <- matrix(velocityScale * vtmp, ncol = nbeam, byrow = TRUE)
+                        v[i, , ] <- matrix(velocityScale * vtmp, ncol = numberOfBeamsToRead, byrow = TRUE)
                     } else if (buf[o] == 0x00 && buf[1 + o] == 0x02) {
                         #<> if (debug > 0 && i == 1) {
                         #<>     cat("  buf[", o + 2, "]: ", buf[o + 2], " (this is q[1,1,1]) NOTE: o=", o, "\n", sep = "")
@@ -1536,7 +1547,7 @@ read.adp.rdi <- function(
                         #<>     }
                         #<> }
                         # q[i, , ] <- matrix(buf[o + 1 + seq(1, items)], ncol = numberOfBeams, byrow = TRUE)
-                        q[i, , ] <- matrix(buf[o + 1 + seq(1, items)], ncol = nbeam, byrow = TRUE)
+                        q[i, , ] <- matrix(buf[o + 1 + seq(1, items)], ncol = numberOfBeamsToRead, byrow = TRUE)
                     } else if (buf[o] == 0x00 && buf[1 + o] == 0x03) {
                         #<> if (debug > 0 && i == 1) {
                         #<>     cat("  buf[", o + 2, "]: ", buf[o + 2], " (this is a[1,1,1]) NOTE: o=", o, "\n", sep = "")
@@ -1545,10 +1556,10 @@ read.adp.rdi <- function(
                         #<>     }
                         #<> }
                         # a[i, , ] <- matrix(buf[o + 1 + seq(1, items)], ncol = numberOfBeams, byrow = TRUE)
-                        a[i, , ] <- matrix(buf[o + 1 + seq(1, items)], ncol = nbeam, byrow = TRUE)
+                        a[i, , ] <- matrix(buf[o + 1 + seq(1, items)], ncol = numberOfBeamsToRead, byrow = TRUE)
                     } else if (buf[o] == 0x00 && buf[1 + o] == 0x04) {
                         # g[i, , ] <- matrix(buf[o + 1 + seq(1, items)], ncol = numberOfBeams, byrow = TRUE)
-                        g[i, , ] <- matrix(buf[o + 1 + seq(1, items)], ncol = nbeam, byrow = TRUE)
+                        g[i, , ] <- matrix(buf[o + 1 + seq(1, items)], ncol = numberOfBeamsToRead, byrow = TRUE)
                     } else if (buf[o] == 0x00 && buf[1 + o] == 0x05) {
                         # FIXME: do something here (what is code 0x00 0x05?)
                     } else if (buf[o] == 0x00 && buf[1 + o] == 0x06) {

--- a/R/adp.rdi.R
+++ b/R/adp.rdi.R
@@ -558,6 +558,14 @@ decodeHeaderRDI <- function(buf, debug = getOption("oceDebug"), tz = getOption("
 #' intstrument (e.g. beam, xyz, sfm, or enu), with the RDI data format manual
 #' indicating how to interpret the resulting arrays.
 #'
+#' \tabular{lllll}{
+#'   **Coordinate System** \tab **Vel1**   \tab **Vel2**   \tab **Vel3**     \tab **Vel4***                   \cr
+#'   Beam                  \tab beam1      \tab beam2      \tab beam3        \tab 0                            \cr
+#'   Instrument            \tab x          \tab y          \tab 0            \tab error                        \cr
+#'   Ship                  \tab x          \tab y          \tab vertical     \tab error (tilt applied)         \cr
+#'   Earth                 \tab east       \tab north      \tab vertical     \tab error (heading applied)      \cr
+#' }
+#'
 #' @template adpTemplate
 #'
 #' @param type character string indicating the type of instrument.

--- a/R/adp.rdi.R
+++ b/R/adp.rdi.R
@@ -547,7 +547,7 @@ decodeHeaderRDI <- function(buf, debug = getOption("oceDebug"), tz = getOption("
 #' century offset is required, then a change will be made to the code.
 #' Even if not, the method should not cause problems for a long time.
 #'
-#' @section Handling of 3-beam Horizontal ADCP (HADCP) files
+#' @section Handling of 3-beam Horizontal ADCP (HADCP) files:
 #'
 #' While most RDI ADCPs contain 4 beams (with the exception of some SentinelV
 #' ADCPs, which stores the vertical beam data in a separate data structure), the

--- a/R/adp.rdi.R
+++ b/R/adp.rdi.R
@@ -283,6 +283,10 @@ decodeHeaderRDI <- function(buf, debug = getOption("oceDebug"), tz = getOption("
     # real.sim.flag <- readBin(FLD[7], "integer", n=1, size=1)
     # lagLength <- readBin(FLD[8], "integer", n=1, size=1, signed=FALSE) # unused
     numberOfBeams <- readBin(FLD[9], "integer", n = 1, size = 1, signed = FALSE)
+    nbeam <- 4 # setting this to use for properly reading p file format (Issue 2639)
+    if (numberOfBeams == 3) {
+        oceDebug(debug, "3 beam (HADCP) detected, setting nbeam=", nbeam, "\n")
+    }
     oceDebug(debug, "numberOfBeams", numberOfBeams, "\n")
     numberOfCells <- abs(readBin(FLD[10], "integer", n = 1, size = 1, signed = FALSE)) # WN
     oceDebug(debug, "numberOfCells", numberOfCells, "\n")
@@ -468,6 +472,7 @@ decodeHeaderRDI <- function(buf, debug = getOption("oceDebug"), tz = getOption("
         dataOffset = dataOffset,
         codes = codes,
         numberOfBeams = numberOfBeams,
+        nbeam = nbeam,
         numberOfCells = numberOfCells,
         pingsPerEnsemble = pingsPerEnsemble,
         cellSize = cellSize,
@@ -954,6 +959,7 @@ read.adp.rdi <- function(
     oceDebug(debug, "have Binary Fixed Attitude Header: ", header$haveBinaryFixedAttitudeHeader, "\n")
     if (header$haveActualData) {
         numberOfBeams <- header$numberOfBeams
+        nbeam <- header$nbeam
         numberOfCells <- header$numberOfCells
         bin1Distance <- header$bin1Distance
         xmitPulseLength <- header$xmitPulseLength
@@ -1130,7 +1136,8 @@ read.adp.rdi <- function(
             oceDebug(debug, "profilesToRead: ", profilesToRead, "\n")
             oceDebug(debug, "numberOfBeams: ", numberOfBeams, "\n")
             oceDebug(debug, "numberOfCells: ", numberOfCells, "\n")
-            items <- numberOfBeams * numberOfCells
+            # items <- numberOfBeams * numberOfCells
+            items <- nbeam * numberOfCells
             codes <- header$codes
             oceDebug(debug, "codes[,1]=", paste("0x", paste(codes[, 1], sep = ""), collapse = " "), "\n")
             oceDebug(debug, "codes[,2]=", paste("0x", paste(codes[, 2], sep = ""), collapse = " "), "\n")
@@ -1185,7 +1192,8 @@ read.adp.rdi <- function(
                 ISMmag <- NULL
             }
             if (vFound) {
-                v <- array(numeric(), dim = c(profilesToRead, numberOfCells, numberOfBeams))
+                # v <- array(numeric(), dim = c(profilesToRead, numberOfCells, numberOfBeams))
+                v <- array(numeric(), dim = c(profilesToRead, numberOfCells, nbeam))
                 oceDebug(
                     debug, "set up 'v' (velocity) storage for ", profilesToRead, " profiles,",
                     numberOfCells, " cells, and ", numberOfBeams, " beams\n"
@@ -1194,7 +1202,8 @@ read.adp.rdi <- function(
                 v <- NULL
             }
             if (qFound) {
-                q <- array(raw(), dim = c(profilesToRead, numberOfCells, numberOfBeams))
+                # q <- array(raw(), dim = c(profilesToRead, numberOfCells, numberOfBeams))
+                q <- array(raw(), dim = c(profilesToRead, numberOfCells, nbeam))
                 oceDebug(
                     debug, "set up 'q' (correlation) storage for ", profilesToRead, " profiles, ",
                     numberOfCells, " cells, and ", numberOfBeams, " beams\n"
@@ -1203,7 +1212,8 @@ read.adp.rdi <- function(
                 q <- NULL
             }
             if (aFound) {
-                a <- array(raw(), dim = c(profilesToRead, numberOfCells, numberOfBeams))
+                # a <- array(raw(), dim = c(profilesToRead, numberOfCells, numberOfBeams))
+                a <- array(raw(), dim = c(profilesToRead, numberOfCells, nbeam))
                 oceDebug(
                     debug, "set up 'a' (echo intensity) storage for ", profilesToRead, " profiles, ",
                     numberOfCells, " cells, and ", numberOfBeams, " beams\n"
@@ -1212,7 +1222,8 @@ read.adp.rdi <- function(
                 a <- NULL
             }
             if (gFound) {
-                g <- array(raw(), dim = c(profilesToRead, numberOfCells, numberOfBeams))
+                # g <- array(raw(), dim = c(profilesToRead, numberOfCells, numberOfBeams))
+                g <- array(raw(), dim = c(profilesToRead, numberOfCells, nbeam))
                 oceDebug(
                     debug, "set up 'g' (percent good) storage for ", profilesToRead, " profiles, ",
                     numberOfCells, " cells, and ", numberOfBeams, " beams\n"
@@ -1433,12 +1444,18 @@ read.adp.rdi <- function(
                 }
             }
             if (bFound) {
-                br <- array(double(), dim = c(profilesToRead, numberOfBeams))
-                bv <- array(double(), dim = c(profilesToRead, numberOfBeams))
+                # br <- array(double(), dim = c(profilesToRead, numberOfBeams))
+                # bv <- array(double(), dim = c(profilesToRead, numberOfBeams))
+                # # bq called bc until 2023-02-09 https://github.com/dankelley/oce/issues/2039
+                # bq <- array(double(), dim = c(profilesToRead, numberOfBeams)) # correlation
+                # ba <- array(double(), dim = c(profilesToRead, numberOfBeams)) # amplitude
+                # bg <- array(double(), dim = c(profilesToRead, numberOfBeams)) # percent good
+                br <- array(double(), dim = c(profilesToRead, nbeam))
+                bv <- array(double(), dim = c(profilesToRead, nbeam))
                 # bq called bc until 2023-02-09 https://github.com/dankelley/oce/issues/2039
-                bq <- array(double(), dim = c(profilesToRead, numberOfBeams)) # correlation
-                ba <- array(double(), dim = c(profilesToRead, numberOfBeams)) # amplitude
-                bg <- array(double(), dim = c(profilesToRead, numberOfBeams)) # percent good
+                bq <- array(double(), dim = c(profilesToRead, nbeam)) # correlation
+                ba <- array(double(), dim = c(profilesToRead, nbeam)) # amplitude
+                bg <- array(double(), dim = c(profilesToRead, nbeam)) # percent good
                 oceDebug(
                     debug, "set up 'br', etc. (bottom data) storage for ", profilesToRead, " profiles, ",
                     numberOfCells, " cells, and ", numberOfBeams, " beams\n"
@@ -1509,7 +1526,8 @@ read.adp.rdi <- function(
                         #<> }
                         vtmp <- readBin(buf[o + 1 + seq(1, 2 * items)], "integer", n = items, size = 2, endian = "little", signed = TRUE)
                         vtmp[-32768 == vtmp] <- NA # blank out bad data
-                        v[i, , ] <- matrix(velocityScale * vtmp, ncol = numberOfBeams, byrow = TRUE)
+                        # v[i, , ] <- matrix(velocityScale * vtmp, ncol = numberOfBeams, byrow = TRUE)
+                        v[i, , ] <- matrix(velocityScale * vtmp, ncol = nbeam, byrow = TRUE)
                     } else if (buf[o] == 0x00 && buf[1 + o] == 0x02) {
                         #<> if (debug > 0 && i == 1) {
                         #<>     cat("  buf[", o + 2, "]: ", buf[o + 2], " (this is q[1,1,1]) NOTE: o=", o, "\n", sep = "")
@@ -1517,7 +1535,8 @@ read.adp.rdi <- function(
                         #<>         cat("  buf[", o + 2 + jjj, "]: ", buf[o + 2 + jjj], "\n", sep = "")
                         #<>     }
                         #<> }
-                        q[i, , ] <- matrix(buf[o + 1 + seq(1, items)], ncol = numberOfBeams, byrow = TRUE)
+                        # q[i, , ] <- matrix(buf[o + 1 + seq(1, items)], ncol = numberOfBeams, byrow = TRUE)
+                        q[i, , ] <- matrix(buf[o + 1 + seq(1, items)], ncol = nbeam, byrow = TRUE)
                     } else if (buf[o] == 0x00 && buf[1 + o] == 0x03) {
                         #<> if (debug > 0 && i == 1) {
                         #<>     cat("  buf[", o + 2, "]: ", buf[o + 2], " (this is a[1,1,1]) NOTE: o=", o, "\n", sep = "")
@@ -1525,9 +1544,11 @@ read.adp.rdi <- function(
                         #<>         cat("  buf[", o + 2 + jjj, "]: ", buf[o + 2 + jjj], "\n", sep = "")
                         #<>     }
                         #<> }
-                        a[i, , ] <- matrix(buf[o + 1 + seq(1, items)], ncol = numberOfBeams, byrow = TRUE)
+                        # a[i, , ] <- matrix(buf[o + 1 + seq(1, items)], ncol = numberOfBeams, byrow = TRUE)
+                        a[i, , ] <- matrix(buf[o + 1 + seq(1, items)], ncol = nbeam, byrow = TRUE)
                     } else if (buf[o] == 0x00 && buf[1 + o] == 0x04) {
-                        g[i, , ] <- matrix(buf[o + 1 + seq(1, items)], ncol = numberOfBeams, byrow = TRUE)
+                        # g[i, , ] <- matrix(buf[o + 1 + seq(1, items)], ncol = numberOfBeams, byrow = TRUE)
+                        g[i, , ] <- matrix(buf[o + 1 + seq(1, items)], ncol = nbeam, byrow = TRUE)
                     } else if (buf[o] == 0x00 && buf[1 + o] == 0x05) {
                         # FIXME: do something here (what is code 0x00 0x05?)
                     } else if (buf[o] == 0x00 && buf[1 + o] == 0x06) {

--- a/man/read.adp.rdi.Rd
+++ b/man/read.adp.rdi.Rd
@@ -147,6 +147,14 @@ as through there are four beams worth of data. The exact meaning of each of
 the "beams" in the data file depends on the coordinate system of the
 intstrument (e.g. beam, xyz, sfm, or enu), with the RDI data format manual
 indicating how to interpret the resulting arrays.
+
+\tabular{lllll}{
+\strong{Coordinate System} \tab \strong{Vel1}   \tab \strong{Vel2}   \tab \strong{Vel3}     \tab \strong{Vel4}*                   \cr
+Beam                 \tab beam1      \tab beam2      \tab beam3        \tab 0                            \cr
+Instrument           \tab x          \tab y          \tab 0            \tab error                        \cr
+Ship                 \tab x          \tab y          \tab vertical     \tab error (tilt applied)         \cr
+Earth                \tab east       \tab north      \tab vertical     \tab error (heading applied)      \cr
+}
 }
 
 \section{Names of items in data slot}{

--- a/man/read.adp.rdi.Rd
+++ b/man/read.adp.rdi.Rd
@@ -136,6 +136,19 @@ century offset is required, then a change will be made to the code.
 Even if not, the method should not cause problems for a long time.
 }
 
+\section{Handling of 3-beam Horizontal ADCP (HADCP) files}{
+
+
+While most RDI ADCPs contain 4 beams (with the exception of some SentinelV
+ADCPs, which stores the vertical beam data in a separate data structure), the
+HADCP (which is a discontinued product in 2026) only has 3 beams. Depsite the
+fact that there are only 3 beams, the pd0 data file format is still written
+as through there are four beams worth of data. The exact meaning of each of
+the "beams" in the data file depends on the coordinate system of the
+intstrument (e.g. beam, xyz, sfm, or enu), with the RDI data format manual
+indicating how to interpret the resulting arrays.
+}
+
 \section{Names of items in data slot}{
 
 


### PR DESCRIPTION
Fixes issue 2639, by making the read.adp.rdi() code always use four beams for interpreting the data structure, even if the physical unit only has _three_ beams.

@dankelley -- can you review, as well as build the docs/webpage, etc?

Thanks!